### PR TITLE
test: add e2e harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ node_modules
 .env
 dist
 .contexts
+playwright-report
+test-results
+packages/e2e/playwright-report
+packages/e2e/test-results

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,12 @@
         "@typescript/native-preview": "^7.0.0-dev.20260310.1",
       },
     },
+    "packages/e2e": {
+      "name": "@eclipsa/e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.52.0",
+      },
+    },
     "packages/eclipsa": {
       "name": "eclipsa",
       "version": "0.1.0",
@@ -40,6 +46,7 @@
       "devDependencies": {
         "@types/babel__core": "^7.20.5",
         "@types/babel__traverse": "^7.20.6",
+        "@typescript/native-preview": "^7.0.0-dev.20260310.1",
       },
       "peerDependencies": {
         "vite": "*",
@@ -90,6 +97,8 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@eclipsa/e2e": ["@eclipsa/e2e@workspace:packages/e2e"],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -198,6 +207,8 @@
     "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.52.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-wu3fquQttzSXwyy8DfdOG3Kyb17yAbRhwPlly7NHSXkrffAEAmZ6+o38tCNgsReGLugbn/wbq4uS4nEQubCq+A=="],
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.52.0", "", { "os": "win32", "cpu": "x64" }, "sha512-wikx9I9J9/lPOZlrCCNgm8YjWkia8NZfhWd1TTvZTMguyChbw/oA2VEM6Fzx+kkpA+1qu5Mo7nrLdOXEJavw8g=="],
+
+    "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -371,6 +382,10 @@
 
     "pixelmatch": ["pixelmatch@7.1.0", "", { "dependencies": { "pngjs": "^7.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng=="],
 
+    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+
+    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
@@ -442,5 +457,7 @@
     "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "pack": "turbo run pack --filter=eclipsa",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
+    "test:e2e": "turbo run e2e --filter=@eclipsa/e2e",
     "fmt": "vp fmt"
   },
   "devDependencies": {

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@eclipsa/e2e",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "e2e": "playwright test",
+    "e2e:headed": "playwright test --headed",
+    "e2e:ui": "playwright test --ui"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0"
+  }
+}

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -1,0 +1,35 @@
+import path from 'node:path'
+import { defineConfig, devices } from '@playwright/test'
+
+const repoRoot = path.resolve(import.meta.dirname, '../..')
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  outputDir: './test-results',
+  use: {
+    baseURL: 'http://127.0.0.1:5173',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'example-dev',
+      testMatch: 'example/**/*.spec.ts',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+  ],
+  webServer: {
+    command: 'bun run dev',
+    cwd: repoRoot,
+    url: 'http://127.0.0.1:5173',
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    timeout: 120_000,
+  },
+})

--- a/packages/e2e/tests/example/example.dev.spec.ts
+++ b/packages/e2e/tests/example/example.dev.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('example app in dev mode', () => {
+  test('renders the SSR shell and adds todos after resume', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(page).toHaveTitle('Document')
+    await expect(page.getByRole('heading', { name: 'Todo List' })).toBeVisible()
+    await expect(page.getByText('Shared layout shell updated')).toBeVisible()
+    await expect(page.getByRole('listitem')).toHaveCount(1)
+    await expect(page.getByRole('listitem').first()).toHaveText('ToDo1')
+
+    const input = page.getByRole('textbox')
+    await input.fill('Ship e2e')
+    await page.getByRole('button', { name: 'Add' }).click()
+
+    await expect(page.getByRole('listitem')).toHaveCount(2)
+    await expect(page.getByRole('listitem').nth(1)).toHaveText('Ship e2e')
+    await expect(input).toHaveValue('')
+  })
+
+  test('keeps layout state across Link navigation', async ({ page }) => {
+    await page.goto('/')
+
+    await page.getByRole('button', { name: /^Layout count:\s*0$/ }).click()
+    await expect(page.getByRole('button', { name: /^Layout count:\s*1$/ })).toBeVisible()
+
+    await page.getByRole('link', { name: 'Open counter with Link' }).click()
+
+    await expect(page).toHaveURL(/\/counter$/)
+    await expect(page.getByText('Counter page')).toBeVisible()
+    await expect(page.getByRole('button', { name: /^Layout count:\s*1$/ })).toBeVisible()
+
+    await page.getByRole('link', { name: 'Back home with Link' }).click()
+
+    await expect(page).toHaveURL(/\/$/)
+    await expect(page.getByRole('button', { name: /^Layout count:\s*1$/ })).toBeVisible()
+  })
+
+  test('navigates imperatively and updates the counter', async ({ page }) => {
+    await page.goto('/')
+
+    await page.getByRole('button', { name: 'Go to counter with navigate()' }).click()
+
+    await expect(page).toHaveURL(/\/counter$/)
+    const counterButton = page.getByRole('button', { name: /^Count:\s*0$/ })
+    await expect(counterButton).toBeVisible()
+    await counterButton.click()
+    await expect(page.getByRole('button', { name: /^Count:\s*1$/ })).toBeVisible()
+
+    await page.getByRole('button', { name: 'Back home with navigate()' }).click()
+
+    await expect(page).toHaveURL(/\/$/)
+    await expect(page.getByRole('button', { name: 'Go to counter with navigate()' })).toBeVisible()
+  })
+})

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,10 @@
     "test": {
       "dependsOn": ["^test"],
       "outputs": []
+    },
+    "e2e": {
+      "cache": false,
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a dedicated `packages/e2e` workspace package for Playwright-based browser tests
- wire a root `bun run test:e2e` command and Turbo `e2e` task for isolated execution
- add dev-mode coverage for the example app SSR shell, todo updates, Link navigation, and `navigate()` flows

## Verification
- `bunx tsc -p tsconfig.json --noEmit`
- `bun run test:e2e`