### PR TITLE
Add resumable onVisible hook

### DIFF
--- a/packages/eclipsa/compiler/analyze/mod.test.ts
+++ b/packages/eclipsa/compiler/analyze/mod.test.ts
@@ -44,6 +44,8 @@ describe('analyzeModule()', () => {
         const count = useSignal(0);
         export default count;
       `),
-    ).rejects.toThrowError('useSignal() can only be called directly inside component$().')
+    ).rejects.toThrowError(
+      'useSignal() can only be used while rendering a component$ and must be called at the top level of the component$ body (not inside nested functions).',
+    )
   })
 })

--- a/packages/eclipsa/compiler/analyze/mod.ts
+++ b/packages/eclipsa/compiler/analyze/mod.ts
@@ -243,6 +243,7 @@ const buildResumeHmrMetadata = (
   identifiers: {
     componentIdentifier?: string
     lazyIdentifier?: string
+    visibleIdentifier?: string
     watchIdentifier?: string
   },
 ) => {
@@ -276,7 +277,8 @@ const buildResumeHmrMetadata = (
         }
 
         const kind =
-          identifiers.lazyIdentifier && calleeName === identifiers.lazyIdentifier
+          (identifiers.lazyIdentifier && calleeName === identifiers.lazyIdentifier) ||
+          (identifiers.visibleIdentifier && calleeName === identifiers.visibleIdentifier)
             ? 'lazy'
             : identifiers.watchIdentifier && calleeName === identifiers.watchIdentifier
               ? 'watch'
@@ -794,11 +796,13 @@ export const analyzeModule = async (
   const eclipsaImports = imports.get('eclipsa')
   const componentIdentifier = eclipsaImports?.get('component$')
   const lazyIdentifier = eclipsaImports?.get('$')
+  const visibleIdentifier = eclipsaImports?.get('onVisible')
   const signalIdentifier = eclipsaImports?.get('useSignal')
   const watchIdentifier = eclipsaImports?.get('useWatch')
   const hmrMetadata = buildResumeHmrMetadata(parsed, {
     componentIdentifier,
     lazyIdentifier,
+    visibleIdentifier,
     watchIdentifier,
   })
 
@@ -932,6 +936,43 @@ export const analyzeModule = async (
               buildCaptureGetter(extracted.captures),
             ]),
           )
+          return
+        }
+
+        if (visibleIdentifier && calleeName === visibleIdentifier) {
+          const argPath = path.get('arguments')[0]
+          if (!argPath?.isArrowFunctionExpression() && !argPath?.isFunctionExpression()) {
+            throw path.buildCodeFrameError(
+              'onVisible() expects a function expression as the first argument.',
+            )
+          }
+
+          const extracted = extractSymbol(argPath as FunctionPath, 'lazy', id)
+          const symbolInfo = hmrMetadata.symbolInfoByFunction.get(argPath.node)
+          builtSymbols.set(extracted.id, {
+            captures: extracted.captures,
+            code: extracted.code,
+            filePath: id,
+            id: extracted.id,
+            kind: extracted.kind,
+          })
+          const hmrKey = symbolInfo?.hmrKey ?? `file:lazy:${extracted.id}`
+          hmrSymbols.set(hmrKey, {
+            captures: extracted.captures,
+            hmrKey,
+            id: extracted.id,
+            kind: extracted.kind,
+            ownerComponentKey: symbolInfo?.ownerComponentKey ?? null,
+            signature: extracted.signature,
+          })
+          hmrKeyBySymbolId.set(extracted.id, hmrKey)
+          usedHelpers.add('__eclipsaLazy')
+
+          path.node.arguments[0] = t.callExpression(t.identifier('__eclipsaLazy'), [
+            t.stringLiteral(extracted.id),
+            t.cloneNode(argPath.node, true),
+            buildCaptureGetter(extracted.captures),
+          ])
           return
         }
 

--- a/packages/eclipsa/compiler/analyze/snapshots/on_visible.jsx.snap
+++ b/packages/eclipsa/compiler/analyze/snapshots/on_visible.jsx.snap
@@ -1,0 +1,41 @@
+// ================= ENTRY (on_visible.jsx) ==
+import { component$, onVisible } from 'eclipsa'
+
+export default component$(() => {
+  const value = 'visible'
+
+  onVisible(() => {
+    console.log(value)
+  })
+
+  return <button>{value}</button>
+})
+
+
+// ================= analyzed ==
+import { __eclipsaComponent, __eclipsaLazy } from "eclipsa/internal";
+import { component$, onVisible } from "eclipsa";
+var analyze_input_default = component$(__eclipsaComponent(() => {
+  const value = "visible";
+  onVisible(__eclipsaLazy("tnnrgm", () => {
+    console.log(value);
+  }, () => [value]));
+  return <button>{value}</button>;
+}, "ezn7f1", () => []));
+export { analyze_input_default as default };
+
+// ================= tnnrgm (lazy) ==
+export default __scope => {
+  console.log(__scope[0]);
+};
+
+// ================= ezn7f1 (component) ==
+import { component$, onVisible } from "eclipsa";
+import { __eclipsaLazy } from "eclipsa/internal";
+export default __scope => {
+  const value = "visible";
+  onVisible(__eclipsaLazy("tnnrgm", () => {
+    console.log(value);
+  }, () => [value]));
+  return <button>{value}</button>;
+};

--- a/packages/eclipsa/compiler/analyze/tests/on_visible.jsx
+++ b/packages/eclipsa/compiler/analyze/tests/on_visible.jsx
@@ -1,0 +1,11 @@
+import { component$, onVisible } from 'eclipsa'
+
+export default component$(() => {
+  const value = 'visible'
+
+  onVisible(() => {
+    console.log(value)
+  })
+
+  return <button>{value}</button>
+})

--- a/packages/eclipsa/core/on-visible.test.tsx
+++ b/packages/eclipsa/core/on-visible.test.tsx
@@ -1,0 +1,356 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { component$ } from './component.ts'
+import { __eclipsaComponent, __eclipsaLazy } from './internal.ts'
+import { createResumeContainer, installResumeListeners } from './runtime.ts'
+import { onVisible } from './signal.ts'
+import { renderSSR } from './ssr.ts'
+
+class FakeNode {
+  nextSibling: FakeNode | null = null
+  parentNode: FakeElement | null = null
+  previousSibling: FakeNode | null = null
+
+  remove() {
+    this.parentNode?.removeChild(this)
+  }
+}
+
+class FakeComment extends FakeNode {
+  constructor(
+    readonly data: string,
+    readonly ownerDocument: FakeDocument,
+  ) {
+    super()
+  }
+}
+
+class FakeElement extends FakeNode {
+  attributes = new Map<string, string>()
+  childNodes: FakeNode[] = []
+
+  constructor(
+    readonly tagName: string,
+    readonly ownerDocument: FakeDocument,
+  ) {
+    super()
+  }
+
+  appendChild(node: FakeNode) {
+    return this.insertBefore(node, null)
+  }
+
+  insertBefore(node: FakeNode, referenceNode: FakeNode | null) {
+    if (node.parentNode) {
+      node.parentNode.removeChild(node)
+    }
+    const nextSibling = referenceNode
+    const previousSibling = nextSibling ? nextSibling.previousSibling : this.childNodes.at(-1) ?? null
+    node.parentNode = this
+    node.previousSibling = previousSibling
+    node.nextSibling = nextSibling
+    if (previousSibling) {
+      previousSibling.nextSibling = node
+    }
+    if (nextSibling) {
+      nextSibling.previousSibling = node
+      const index = this.childNodes.indexOf(nextSibling)
+      this.childNodes.splice(index, 0, node)
+    } else {
+      this.childNodes.push(node)
+    }
+    return node
+  }
+
+  querySelectorAll() {
+    return [] as unknown as NodeListOf<Element>
+  }
+
+  removeChild(node: FakeNode) {
+    const index = this.childNodes.indexOf(node)
+    if (index < 0) {
+      return node
+    }
+    const previousSibling = node.previousSibling
+    const nextSibling = node.nextSibling
+    if (previousSibling) {
+      previousSibling.nextSibling = nextSibling
+    }
+    if (nextSibling) {
+      nextSibling.previousSibling = previousSibling
+    }
+    this.childNodes.splice(index, 1)
+    node.parentNode = null
+    node.previousSibling = null
+    node.nextSibling = null
+    return node
+  }
+
+  setAttribute(name: string, value: string) {
+    this.attributes.set(name, value)
+  }
+}
+
+class FakeWindow {
+  innerHeight = 100
+  innerWidth = 100
+  #listeners = new Map<string, Set<() => void>>()
+
+  addEventListener(eventName: string, listener: () => void) {
+    const listeners = this.#listeners.get(eventName) ?? new Set()
+    listeners.add(listener)
+    this.#listeners.set(eventName, listeners)
+  }
+
+  emit(eventName: string) {
+    for (const listener of this.#listeners.get(eventName) ?? []) {
+      listener()
+    }
+  }
+
+  removeEventListener(eventName: string, listener: () => void) {
+    this.#listeners.get(eventName)?.delete(listener)
+  }
+}
+
+class FakeRange {
+  constructor(private readonly doc: FakeDocument) {}
+
+  getBoundingClientRect() {
+    if (this.doc.visible) {
+      return {
+        bottom: 10,
+        left: 0,
+        right: 10,
+        top: 0,
+      }
+    }
+    return {
+      bottom: 0,
+      left: 0,
+      right: 0,
+      top: 0,
+    }
+  }
+
+  getClientRects() {
+    const rect = this.getBoundingClientRect()
+    return rect.bottom > 0
+      ? ({
+          0: rect,
+          length: 1,
+        } as unknown as DOMRectList)
+      : ({
+          length: 0,
+        } as unknown as DOMRectList)
+  }
+
+  setEndBefore(_node: FakeComment) {}
+
+  setStartAfter(_node: FakeComment) {}
+}
+
+class FakeTreeWalker {
+  currentNode: Comment | null = null
+  #index = -1
+
+  constructor(private readonly comments: FakeComment[]) {}
+
+  nextNode() {
+    this.#index += 1
+    this.currentNode = (this.comments[this.#index] ?? null) as unknown as Comment | null
+    return this.currentNode
+  }
+}
+
+class FakeDocument {
+  body = new FakeElement('body', this) as unknown as HTMLElement
+  defaultView = new FakeWindow() as unknown as Window
+  location = { pathname: '/' } as Location
+  visible = false
+  #listeners = new Map<string, Set<() => void>>()
+  #comments: FakeComment[]
+
+  constructor() {
+    const start = new FakeComment('ec:c:c0:start', this)
+    const element = new FakeElement('div', this)
+    const end = new FakeComment('ec:c:c0:end', this)
+    ;(this.body as unknown as FakeElement).appendChild(start)
+    ;(this.body as unknown as FakeElement).appendChild(element)
+    ;(this.body as unknown as FakeElement).appendChild(end)
+    this.#comments = [start, end]
+  }
+
+  addEventListener(eventName: string, listener: () => void) {
+    const listeners = this.#listeners.get(eventName) ?? new Set()
+    listeners.add(listener)
+    this.#listeners.set(eventName, listeners)
+  }
+
+  createComment(data: string) {
+    return new FakeComment(data, this) as unknown as Comment
+  }
+
+  createElement(tagName: string) {
+    return new FakeElement(tagName, this) as unknown as HTMLElement
+  }
+
+  createRange() {
+    return new FakeRange(this) as unknown as Range
+  }
+
+  createTextNode(data: string) {
+    return new FakeComment(data, this) as unknown as Text
+  }
+
+  createTreeWalker() {
+    return new FakeTreeWalker(this.#comments)
+  }
+
+  querySelectorAll() {
+    return [] as unknown as NodeListOf<Element>
+  }
+
+  emit(eventName: string) {
+    for (const listener of this.#listeners.get(eventName) ?? []) {
+      listener()
+    }
+  }
+
+  removeEventListener(eventName: string, listener: () => void) {
+    this.#listeners.get(eventName)?.delete(listener)
+  }
+}
+
+const withFakeVisibleDocument = async (fn: (doc: Document, fakeWindow: FakeWindow) => Promise<void>) => {
+  const OriginalComment = globalThis.Comment
+  const OriginalDocument = globalThis.Document
+  const OriginalNode = globalThis.Node
+  const OriginalNodeFilter = globalThis.NodeFilter
+
+  globalThis.Comment = FakeComment as unknown as typeof Comment
+  globalThis.Document = FakeDocument as unknown as typeof Document
+  globalThis.Node = FakeNode as unknown as typeof Node
+  globalThis.NodeFilter = { SHOW_COMMENT: 128 } as typeof NodeFilter
+
+  try {
+    const doc = new FakeDocument() as unknown as Document
+    await fn(doc, (doc as unknown as FakeDocument).defaultView as unknown as FakeWindow)
+  } finally {
+    globalThis.Comment = OriginalComment
+    globalThis.Document = OriginalDocument
+    globalThis.Node = OriginalNode
+    globalThis.NodeFilter = OriginalNodeFilter
+  }
+}
+
+const flushAsync = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await Promise.resolve()
+}
+
+describe('onVisible', () => {
+  it('does not run during SSR and serializes resumable visibility callbacks', () => {
+    const visible = vi.fn()
+    const App = component$(
+      __eclipsaComponent(
+        () => {
+          onVisible(
+            __eclipsaLazy(
+              'visible-symbol',
+              () => {
+                visible()
+              },
+              () => [],
+            ),
+          )
+
+          return <button>ready</button>
+        },
+        'component-symbol',
+        () => [],
+      ),
+    )
+
+    const { html, payload } = renderSSR(() => <App />)
+
+    expect(html).toContain('<button>ready</button>')
+    expect(visible).not.toHaveBeenCalled()
+    expect(payload.components.c0?.visibleCount).toBe(1)
+    expect(payload.visibles['c0:v0']).toEqual({
+      componentId: 'c0',
+      scope: expect.any(String),
+      symbol: 'visible-symbol',
+    })
+  })
+
+  it('runs when a resumed SSR boundary becomes visible without activating the component', async () => {
+    await withFakeVisibleDocument(async (doc, fakeWindow) => {
+      const globalRecord = globalThis as Record<PropertyKey, unknown>
+      globalRecord.__eclipsaVisibleRuns = 0
+
+      const container = createResumeContainer(doc, {
+        components: {
+          c0: {
+            props: {},
+            scope: 'sc0',
+            signalIds: [],
+            symbol: 'page-symbol',
+            visibleCount: 1,
+            watchCount: 0,
+          },
+        },
+        scopes: {
+          sc0: [],
+          sc1: [],
+        },
+        signals: {
+          '$router:isNavigating': false,
+          '$router:path': '/',
+        },
+        subscriptions: {
+          '$router:isNavigating': [],
+          '$router:path': [],
+        },
+        symbols: {
+          'visible-symbol': '/virtual/on-visible-symbol.js',
+        },
+        visibles: {
+          'c0:v0': {
+            componentId: 'c0',
+            scope: 'sc1',
+            symbol: 'visible-symbol',
+          },
+        },
+        watches: {},
+      })
+      container.imports.set(
+        'visible-symbol',
+        Promise.resolve({
+          default: () => {
+            const current = globalRecord.__eclipsaVisibleRuns
+            globalRecord.__eclipsaVisibleRuns = typeof current === 'number' ? current + 1 : 1
+          },
+        }),
+      )
+      const cleanup = installResumeListeners(container)
+
+      await flushAsync()
+      expect(globalRecord.__eclipsaVisibleRuns).toBe(0)
+
+      ;(doc as unknown as FakeDocument).visible = true
+      fakeWindow.emit('resize')
+      await flushAsync()
+
+      expect(globalRecord.__eclipsaVisibleRuns).toBe(1)
+      expect(container.components.get('c0')?.active).toBe(false)
+
+      fakeWindow.emit('resize')
+      await flushAsync()
+      expect(globalRecord.__eclipsaVisibleRuns).toBe(1)
+
+      cleanup()
+      delete globalRecord.__eclipsaVisibleRuns
+    })
+  })
+})

--- a/packages/eclipsa/core/resume.test.ts
+++ b/packages/eclipsa/core/resume.test.ts
@@ -22,6 +22,9 @@ const createContainer = (overrides?: Partial<RuntimeContainer>) =>
     scopes: new Map(),
     signals: new Map(),
     symbols: new Map(),
+    visibilityCheckQueued: false,
+    visibilityListenersCleanup: null,
+    visibles: new Map(),
     watches: new Map(),
     ...overrides,
   }) as RuntimeContainer
@@ -119,6 +122,7 @@ describe('resume HMR runtime helpers', () => {
             signalIds: [],
             start: {} as Comment,
             symbol: 'old-symbol',
+            visibleCount: 0,
             watchCount: 0,
           },
         ],
@@ -128,6 +132,20 @@ describe('resume HMR runtime helpers', () => {
         ['mid-symbol', Promise.resolve({ default: () => null })],
       ]),
       symbols: new Map([['old-symbol', '/app/+page.tsx?eclipsa-symbol=old-symbol']]),
+      visibles: new Map([
+        [
+          'v0',
+          {
+            componentId: 'c0',
+            done: false,
+            id: 'v0',
+            pending: null,
+            run: null,
+            scopeId: 'scope-root',
+            symbol: 'old-symbol',
+          },
+        ],
+      ]),
       watches: new Map([
         [
           'w0',
@@ -155,6 +173,7 @@ describe('resume HMR runtime helpers', () => {
       'old-symbol': '/app/+page.tsx?eclipsa-symbol=mid-symbol',
     })
     expect(container.components.get('c0')?.symbol).toBe('mid-symbol')
+    expect(container.visibles.get('v0')?.symbol).toBe('mid-symbol')
     expect(container.watches.get('w0')?.symbol).toBe('mid-symbol')
     expect(collectResumeHmrBoundaryIds(container, ['mid-symbol'])).toEqual(['c0'])
 
@@ -166,6 +185,7 @@ describe('resume HMR runtime helpers', () => {
     expect(container.symbols.get('mid-symbol')).toBe('/app/+page.tsx?eclipsa-symbol=next-symbol')
     expect(container.symbols.get('next-symbol')).toBe('/app/+page.tsx?eclipsa-symbol=next-symbol')
     expect(container.components.get('c0')?.symbol).toBe('next-symbol')
+    expect(container.visibles.get('v0')?.symbol).toBe('next-symbol')
     expect(container.watches.get('w0')?.symbol).toBe('next-symbol')
     expect(collectResumeHmrBoundaryIds(container, ['next-symbol'])).toEqual(['c0'])
     expect(container.imports.has('old-symbol')).toBe(false)
@@ -189,6 +209,7 @@ describe('resume HMR runtime helpers', () => {
             signalIds: [],
             start: {} as Comment,
             symbol: 'page-symbol',
+            visibleCount: 0,
             watchCount: 0,
           },
         ],
@@ -203,6 +224,7 @@ describe('resume HMR runtime helpers', () => {
             scopeId: 'scope-header',
             signalIds: [],
             symbol: 'header-symbol',
+            visibleCount: 0,
             watchCount: 0,
           },
         ],
@@ -228,6 +250,7 @@ describe('resume HMR runtime helpers', () => {
             signalIds: [],
             start: {} as Comment,
             symbol: 'page-symbol',
+            visibleCount: 0,
             watchCount: 0,
           },
         ],
@@ -286,6 +309,7 @@ describe('resume HMR runtime helpers', () => {
         },
         subscriptions: {},
         symbols: {},
+        visibles: {},
         watches: {},
       })
 
@@ -307,6 +331,7 @@ describe('resume HMR runtime helpers', () => {
               scope: 'sc0',
               signalIds: ['s0'],
               symbol: 'page-symbol',
+              visibleCount: 0,
               watchCount: 0,
             },
           },
@@ -324,6 +349,7 @@ describe('resume HMR runtime helpers', () => {
             '$router:path': [],
           },
           symbols: {},
+          visibles: {},
           watches: {},
         })
 

--- a/packages/eclipsa/core/runtime.test.ts
+++ b/packages/eclipsa/core/runtime.test.ts
@@ -67,6 +67,9 @@ const createContainer = () =>
     scopes: new Map(),
     signals: new Map(),
     symbols: new Map(),
+    visibilityCheckQueued: false,
+    visibilityListenersCleanup: null,
+    visibles: new Map(),
     watches: new Map(),
   }) as RuntimeContainer
 

--- a/packages/eclipsa/core/runtime.ts
+++ b/packages/eclipsa/core/runtime.ts
@@ -80,6 +80,7 @@ export interface ResumeComponentPayload {
   scope: string
   signalIds: string[]
   symbol: string
+  visibleCount: number
   watchCount: number
 }
 
@@ -91,12 +92,19 @@ interface ResumeWatchPayload {
   symbol: string
 }
 
+interface ResumeVisiblePayload {
+  componentId: string
+  scope: string
+  symbol: string
+}
+
 export interface ResumePayload {
   components: Record<string, ResumeComponentPayload>
   scopes: Record<string, ResumeScopeSlot[]>
   signals: Record<string, EncodedValue>
   subscriptions: Record<string, string[]>
   symbols: Record<string, string>
+  visibles: Record<string, ResumeVisiblePayload>
   watches: Record<string, ResumeWatchPayload>
 }
 
@@ -121,6 +129,7 @@ interface ComponentState {
   signalIds: string[]
   start?: Comment
   symbol: string
+  visibleCount: number
   watchCount: number
 }
 
@@ -132,6 +141,7 @@ interface RenderFrame {
   visitedDescendants: Set<string>
   mode: 'client' | 'ssr'
   signalCursor: number
+  visibleCursor: number
   watchCursor: number
 }
 
@@ -166,6 +176,9 @@ export interface RuntimeContainer {
   scopes: Map<string, ResumeScopeSlot[]>
   signals: Map<string, SignalRecord>
   symbols: Map<string, string>
+  visibilityListenersCleanup: (() => void) | null
+  visibilityCheckQueued: boolean
+  visibles: Map<string, VisibleState>
   watches: Map<string, WatchState>
 }
 
@@ -215,6 +228,16 @@ interface WatchState {
   scopeId: string
   symbol: string
   track: (() => void) | null
+}
+
+interface VisibleState {
+  componentId: string
+  done: boolean
+  id: string
+  pending: Promise<void> | null
+  run: (() => void | Promise<void>) | null
+  scopeId: string
+  symbol: string
 }
 
 interface PendingLinkNavigation {
@@ -442,6 +465,9 @@ const createContainer = (symbols: Record<string, string>, doc?: Document): Runti
   scopes: new Map(),
   signals: new Map(),
   symbols: new Map(Object.entries(symbols)),
+  visibilityCheckQueued: false,
+  visibilityListenersCleanup: null,
+  visibles: new Map(),
   watches: new Map(),
 })
 
@@ -731,6 +757,7 @@ const createFrame = (
   mountCallbacks: [],
   mode,
   signalCursor: 0,
+  visibleCursor: 0,
   visitedDescendants: new Set(),
   watchCursor: 0,
 })
@@ -767,6 +794,7 @@ const getOrCreateComponentState = (
     scopeId: registerScope(container, []),
     signalIds: [],
     symbol,
+    visibleCount: 0,
     watchCount: 0,
   }
   container.components.set(id, component)
@@ -781,10 +809,12 @@ const resetComponentForSymbolChange = (
   component.didMount = false
   component.scopeId = registerScope(container, meta.captures())
   component.signalIds = []
+  pruneComponentVisibles(container, component, 0)
   pruneComponentWatches(container, component, 0)
 }
 
 const createWatchId = (componentId: string, watchIndex: number) => `${componentId}:w${watchIndex}`
+const createVisibleId = (componentId: string, visibleIndex: number) => `${componentId}:v${visibleIndex}`
 
 const getOrCreateWatchState = (
   container: RuntimeContainer,
@@ -847,6 +877,30 @@ const getOrCreateWatchState = (
   return watch
 }
 
+const getOrCreateVisibleState = (
+  container: RuntimeContainer,
+  id: string,
+  componentId: string,
+): VisibleState => {
+  const existing = container.visibles.get(id)
+  if (existing) {
+    existing.componentId = componentId
+    return existing
+  }
+
+  const visible: VisibleState = {
+    componentId,
+    done: false,
+    id,
+    pending: null,
+    run: null,
+    scopeId: registerScope(container, []),
+    symbol: '',
+  }
+  container.visibles.set(id, visible)
+  return visible
+}
+
 const clearComponentSubscriptions = (container: RuntimeContainer, componentId: string) => {
   for (const record of container.signals.values()) {
     record.subscribers.delete(componentId)
@@ -862,6 +916,10 @@ const removeWatchState = (container: RuntimeContainer, watchId: string) => {
   container.watches.delete(watchId)
 }
 
+const removeVisibleState = (container: RuntimeContainer, visibleId: string) => {
+  container.visibles.delete(visibleId)
+}
+
 const pruneComponentWatches = (
   container: RuntimeContainer,
   component: ComponentState,
@@ -871,6 +929,17 @@ const pruneComponentWatches = (
     removeWatchState(container, createWatchId(component.id, index))
   }
   component.watchCount = nextCount
+}
+
+const pruneComponentVisibles = (
+  container: RuntimeContainer,
+  component: ComponentState,
+  nextCount: number,
+) => {
+  for (let index = nextCount; index < component.visibleCount; index++) {
+    removeVisibleState(container, createVisibleId(component.id, index))
+  }
+  component.visibleCount = nextCount
 }
 
 const isDescendantOf = (parentId: string, candidateId: string) =>
@@ -891,6 +960,7 @@ const pruneRemovedComponents = (
     clearComponentSubscriptions(container, descendantId)
     const descendant = container.components.get(descendantId)
     if (descendant) {
+      pruneComponentVisibles(container, descendant, 0)
       pruneComponentWatches(container, descendant, 0)
     }
     container.components.delete(descendantId)
@@ -903,6 +973,134 @@ const scheduleMicrotask = (fn: () => void) => {
     return
   }
   Promise.resolve().then(fn)
+}
+
+const scheduleVisibleCallbacksCheck = (container: RuntimeContainer) => {
+  if (container.visibilityCheckQueued || container.visibles.size === 0 || !container.doc) {
+    return
+  }
+
+  ensureVisibilityListeners(container)
+  container.visibilityCheckQueued = true
+  const run = () => {
+    container.visibilityCheckQueued = false
+    void flushVisibleCallbacks(container)
+  }
+
+  const view = container.doc.defaultView
+  if (view && typeof view.requestAnimationFrame === 'function') {
+    view.requestAnimationFrame(() => run())
+    return
+  }
+
+  scheduleMicrotask(run)
+}
+
+const rectIntersectsViewport = (
+  view: { innerHeight?: number; innerWidth?: number },
+  rect: { bottom: number; left: number; right: number; top: number },
+) => {
+  const viewportHeight = view.innerHeight ?? 0
+  const viewportWidth = view.innerWidth ?? 0
+  return rect.bottom > 0 && rect.right > 0 && rect.top < viewportHeight && rect.left < viewportWidth
+}
+
+const isBoundaryVisible = (doc: Document, start: Comment, end: Comment) => {
+  const view = doc.defaultView
+  if (typeof doc.createRange !== 'function' || !view) {
+    return false
+  }
+
+  const range = doc.createRange()
+  range.setStartAfter(start)
+  range.setEndBefore(end)
+
+  const rects = range.getClientRects()
+  if (rects.length === 0) {
+    return rectIntersectsViewport(view, range.getBoundingClientRect())
+  }
+
+  for (let index = 0; index < rects.length; index++) {
+    const rect = rects[index]
+    if (rectIntersectsViewport(view, rect)) {
+      return true
+    }
+  }
+  return false
+}
+
+const runVisibleCallback = async (container: RuntimeContainer, visible: VisibleState) => {
+  if (visible.done) {
+    return
+  }
+
+  visible.done = true
+  const pending = Promise.resolve()
+    .then(async () => {
+      if (visible.run) {
+        await withClientContainer(container, async () => {
+          await visible.run?.()
+        })
+      } else {
+        const module = await loadSymbol(container, visible.symbol)
+        await withClientContainer(container, async () => {
+          await module.default(materializeScope(container, visible.scopeId))
+        })
+      }
+      await flushDirtyComponents(container)
+      scheduleVisibleCallbacksCheck(container)
+    })
+    .finally(() => {
+      if (visible.pending === pending) {
+        visible.pending = null
+      }
+    })
+
+  visible.pending = pending
+  await pending
+}
+
+const flushVisibleCallbacks = async (container: RuntimeContainer) => {
+  if (!container.doc || container.visibles.size === 0) {
+    return
+  }
+
+  for (const visible of [...container.visibles.values()]) {
+    if (visible.done || visible.pending) {
+      continue
+    }
+
+    const component = container.components.get(visible.componentId)
+    if (!component?.start || !component.end) {
+      continue
+    }
+
+    if (!isBoundaryVisible(container.doc, component.start, component.end)) {
+      continue
+    }
+
+    await runVisibleCallback(container, visible)
+  }
+}
+
+const ensureVisibilityListeners = (container: RuntimeContainer) => {
+  if (container.visibilityListenersCleanup || !container.doc) {
+    return
+  }
+
+  const doc = container.doc
+  const onVisibilityChange = () => {
+    scheduleVisibleCallbacksCheck(container)
+  }
+
+  doc.addEventListener('scroll', onVisibilityChange, true)
+  doc.defaultView?.addEventListener('resize', onVisibilityChange)
+
+  container.visibilityListenersCleanup = () => {
+    doc.removeEventListener('scroll', onVisibilityChange, true)
+    doc.defaultView?.removeEventListener('resize', onVisibilityChange)
+    container.visibilityListenersCleanup = null
+  }
 }
 
 const scheduleMountCallbacks = (
@@ -919,7 +1117,11 @@ const scheduleMountCallbacks = (
       for (const callback of callbacks) {
         callback()
       }
-    }).then(() => flushDirtyComponents(container))
+    })
+      .then(() => flushDirtyComponents(container))
+      .then(() => {
+        scheduleVisibleCallbacksCheck(container)
+      })
   })
 }
 
@@ -1333,6 +1535,7 @@ const renderStringNode = (inputElementLike: JSX.Element | JSX.Element[]): string
 
     const componentFn = resolved.type as Component
     const body = pushFrame(frame, () => renderStringNode(componentFn(evaluatedProps)))
+    pruneComponentVisibles(container, component, frame.visibleCursor)
     pruneComponentWatches(container, component, frame.watchCursor)
     return `<!--ec:c:${componentId}:start-->${body}<!--ec:c:${componentId}:end-->`
   }
@@ -1439,6 +1642,7 @@ const renderComponentToNodes = (
   component.start = start
   component.end = end
   const rendered = pushFrame(frame, () => toMountedNodes(componentFn(props), container))
+  pruneComponentVisibles(container, component, frame.visibleCursor)
   pruneComponentWatches(container, component, frame.watchCursor)
   pruneRemovedComponents(container, componentId, frame.visitedDescendants)
 
@@ -1458,6 +1662,7 @@ const renderComponentToNodes = (
   }
 
   scheduleMountCallbacks(container, component, frame.mountCallbacks)
+  scheduleVisibleCallbacksCheck(container)
 
   return [start, ...rendered, end]
 }
@@ -1724,6 +1929,7 @@ const resetContainerForRouteRender = (container: RuntimeContainer) => {
   container.nextSignalId = 0
   container.rootChildCursor = 0
   container.scopes.clear()
+  container.visibles.clear()
   container.watches.clear()
 
   for (const [id, record] of [...container.signals.entries()]) {
@@ -1812,6 +2018,7 @@ const renderRouteIntoRoot = (
   rootComponent.signalIds = []
   rootComponent.start = undefined
   rootComponent.watchCount = 0
+  rootComponent.visibleCount = 0
 
   clearComponentSubscriptions(container, rootComponent.id)
   const frame = createFrame(container, rootComponent, 'client')
@@ -1821,6 +2028,7 @@ const renderRouteIntoRoot = (
       return toMountedNodes(rendered, container)
     }),
   )
+  pruneComponentVisibles(container, rootComponent, frame.visibleCursor)
   pruneComponentWatches(container, rootComponent, frame.watchCursor)
   scheduleMountCallbacks(container, rootComponent, frame.mountCallbacks)
 
@@ -1838,6 +2046,7 @@ const renderRouteIntoRoot = (
   rootComponent.start = start
   rootComponent.end = end
   bindRouterLinks(container, root)
+  scheduleVisibleCallbacksCheck(container)
 }
 
 const loadRouteModule = async (url: string): Promise<LoadedRouteModule> => {
@@ -2105,6 +2314,7 @@ export const renderClientComponent = <T>(componentFn: Component<T>, props: T): u
   const oldDescendants = collectDescendantIds(container, componentId)
   clearComponentSubscriptions(container, componentId)
   const rendered = pushFrame(frame, () => componentFn(props))
+  pruneComponentVisibles(container, component, frame.visibleCursor)
   pruneComponentWatches(container, component, frame.watchCursor)
   pruneRemovedComponents(container, componentId, frame.visitedDescendants)
 
@@ -2121,6 +2331,7 @@ export const renderClientComponent = <T>(componentFn: Component<T>, props: T): u
   }
 
   scheduleMountCallbacks(container, component, frame.mountCallbacks)
+  scheduleVisibleCallbacksCheck(container)
 
   return rendered
 }
@@ -2143,6 +2354,7 @@ const activateComponent = async (container: RuntimeContainer, componentId: strin
       return toMountedNodes(rendered, container)
     }),
   )
+  pruneComponentVisibles(container, component, frame.visibleCursor)
   pruneComponentWatches(container, component, frame.watchCursor)
   replaceBoundaryContents(component.start, component.end, nodes)
   if (component.start.parentNode && 'querySelectorAll' in component.start.parentNode) {
@@ -2171,6 +2383,7 @@ const activateComponent = async (container: RuntimeContainer, componentId: strin
   }
   clearComponentSubscriptions(container, componentId)
   scheduleMountCallbacks(container, component, frame.mountCallbacks)
+  scheduleVisibleCallbacksCheck(container)
 }
 
 const sortDirtyComponents = (ids: Iterable<string>) =>
@@ -2264,6 +2477,12 @@ export const applyResumeHmrSymbolReplacements = (
     for (const watch of container.watches.values()) {
       if (affectedIds.has(watch.symbol)) {
         watch.symbol = nextSymbolId
+      }
+    }
+
+    for (const visible of container.visibles.values()) {
+      if (affectedIds.has(visible.symbol)) {
+        visible.symbol = nextSymbolId
       }
     }
 
@@ -2375,6 +2594,7 @@ export const beginSSRContainer = <T>(
     scopeId: registerScope(container, []),
     signalIds: [],
     symbol: ROOT_COMPONENT_ID,
+    visibleCount: 0,
     watchCount: 0,
   }
 
@@ -2395,6 +2615,7 @@ export const toResumePayload = (container: RuntimeContainer): ResumePayload => (
         scope: component.scopeId,
         signalIds: [...component.signalIds],
         symbol: component.symbol,
+        visibleCount: component.visibleCount,
         watchCount: component.watchCount,
       } satisfies ResumeComponentPayload,
     ]),
@@ -2407,6 +2628,16 @@ export const toResumePayload = (container: RuntimeContainer): ResumePayload => (
     [...container.signals.entries()].map(([id, record]) => [id, [...record.subscribers]]),
   ),
   symbols: Object.fromEntries(container.symbols.entries()),
+  visibles: Object.fromEntries(
+    [...container.visibles.entries()].map(([id, visible]) => [
+      id,
+      {
+        componentId: visible.componentId,
+        scope: visible.scopeId,
+        symbol: visible.symbol,
+      } satisfies ResumeVisiblePayload,
+    ]),
+  ),
   watches: Object.fromEntries(
     [...container.watches.entries()].map(([id, watch]) => [
       id,
@@ -2455,6 +2686,7 @@ export const createResumeContainer = (
       scopeId: componentPayload.scope,
       signalIds: [...componentPayload.signalIds],
       symbol: componentPayload.symbol,
+      visibleCount: componentPayload.visibleCount ?? 0,
       watchCount: componentPayload.watchCount,
     })
   }
@@ -2486,6 +2718,15 @@ export const createResumeContainer = (
     }
   }
 
+  for (const [id, visiblePayload] of Object.entries(payload.visibles ?? {})) {
+    const visible = getOrCreateVisibleState(container, id, visiblePayload.componentId)
+    visible.done = false
+    visible.pending = null
+    visible.run = null
+    visible.scopeId = visiblePayload.scope
+    visible.symbol = visiblePayload.symbol
+  }
+
   for (const [id, boundary] of scanComponentBoundaries(root as HTMLElement)) {
     const component = container.components.get(id)
     if (!component) {
@@ -2498,6 +2739,7 @@ export const createResumeContainer = (
   const router = ensureRouterState(container)
   router.currentPath.value = normalizeRoutePath(doc.location.pathname)
   router.isNavigating.value = false
+  scheduleVisibleCallbacksCheck(container)
 
   return container
 }
@@ -2698,6 +2940,8 @@ export const installResumeListeners = (container: RuntimeContainer) => {
     return () => {}
   }
   bindRouterLinks(container, doc)
+  ensureVisibilityListeners(container)
+  scheduleVisibleCallbacksCheck(container)
   const listeners = ['click', 'input', 'change', 'submit'] as const
   const onEvent = (event: Event) => {
     void dispatchDocumentEvent(container, event)
@@ -2718,6 +2962,7 @@ export const installResumeListeners = (container: RuntimeContainer) => {
       doc.removeEventListener(eventName, onEvent, true)
     }
     doc.defaultView?.removeEventListener('popstate', onPopState)
+    container.visibilityListenersCleanup?.()
   }
 }
 
@@ -2768,6 +3013,29 @@ export const createOnMount = (fn: () => void) => {
     return
   }
   frame.mountCallbacks.push(fn)
+}
+
+export const createOnVisible = (fn: () => void) => {
+  const container = getCurrentContainer()
+  const frame = getCurrentFrame()
+  const lazyMeta = getLazyMeta(fn)
+
+  if (!container || !frame || frame.component.id === ROOT_COMPONENT_ID) {
+    return
+  }
+
+  if (!lazyMeta && frame.mode === 'ssr') {
+    return
+  }
+
+  const visibleIndex = frame.visibleCursor++
+  const visibleId = createVisibleId(frame.component.id, visibleIndex)
+  const visible = getOrCreateVisibleState(container, visibleId, frame.component.id)
+  visible.scopeId = lazyMeta ? registerScope(container, lazyMeta.captures()) : registerScope(container, [])
+  visible.symbol = lazyMeta?.symbol ?? ''
+  visible.run = lazyMeta ? null : fn
+
+  scheduleVisibleCallbacksCheck(container)
 }
 
 export const createWatch = (fn: () => void, dependencies?: WatchDependency[]) => {

--- a/packages/eclipsa/core/signal.test.ts
+++ b/packages/eclipsa/core/signal.test.ts
@@ -67,6 +67,9 @@ const createContainer = () =>
     scopes: new Map(),
     signals: new Map(),
     symbols: new Map(),
+    visibilityCheckQueued: false,
+    visibilityListenersCleanup: null,
+    visibles: new Map(),
     watches: new Map(),
   }) as RuntimeContainer
 

--- a/packages/eclipsa/core/signal.ts
+++ b/packages/eclipsa/core/signal.ts
@@ -1,4 +1,10 @@
-import { createEffect, createOnMount, createWatch, useRuntimeSignal } from './runtime.ts'
+import {
+  createEffect,
+  createOnMount,
+  createOnVisible,
+  createWatch,
+  useRuntimeSignal,
+} from './runtime.ts'
 
 export interface Signal<T> {
   value: T
@@ -15,6 +21,7 @@ export const useSignal: UseSignal = (value) => useRuntimeSignal(value)
 
 export const effect = createEffect
 export const onMount = createOnMount
+export const onVisible = createOnVisible as (fn: () => void) => void
 export const useWatch = createWatch as (fn: () => void, dependencies?: WatchDependency[]) => void
 
 export const useComputed$ = <T>(fn: () => T) => {

--- a/packages/eclipsa/vite/compiler.test.ts
+++ b/packages/eclipsa/vite/compiler.test.ts
@@ -241,6 +241,52 @@ describe('createResumeHmrUpdate', () => {
     )
   })
 
+  it('treats onVisible callbacks as lazy symbol URL replacements', async () => {
+    const previous = await analyze(
+      `
+      import { component$, onVisible } from "eclipsa";
+      export default component$(() => {
+        const label = "ready";
+        onVisible(() => {
+          console.log(label);
+        });
+        return <div>{label}</div>;
+      });
+    `,
+      '/tmp/on-visible.tsx',
+    )
+    const next = await analyze(
+      `
+      import { component$, onVisible } from "eclipsa";
+      export default component$(() => {
+        const label = "ready";
+        onVisible(() => {
+          console.log(label.toUpperCase());
+        });
+        return <div>{label}</div>;
+      });
+    `,
+      '/tmp/on-visible.tsx',
+    )
+
+    const update = createResumeHmrUpdate({
+      filePath: '/tmp/on-visible.tsx',
+      next,
+      previous,
+      root: '/tmp',
+    })
+    const previousSymbolId = [...previous.hmrManifest.symbols.values()].find(
+      (entry) => entry.kind === 'lazy',
+    )?.id
+
+    expect(update?.fullReload).toBe(false)
+    expect(update?.rerenderOwnerSymbols).toEqual([])
+    expect(previousSymbolId).toBeTruthy()
+    expect(
+      previousSymbolId ? update?.symbolUrlReplacements[previousSymbolId] : undefined,
+    ).toMatch(/\?eclipsa-symbol=/)
+  })
+
   it('falls back to full reload when top-level component membership changes', async () => {
     const previous = await analyze(
       `


### PR DESCRIPTION
## Summary
- add a public `onVisible()` hook that registers resumable visibility callbacks without requiring initial component activation
- restore serialized visibility callbacks from the SSR resume payload and trigger them once a paused boundary becomes visible
- teach the analyzer/compiler to extract `onVisible(() => ...)` into lazy resumable symbols and cover the behavior with runtime/compiler tests

## Verification
- `bun run test`
- `bun run test` in `packages/eclipsa`
- `bun run typecheck` in `packages/eclipsa`
- `bun test packages/eclipsa/core/on-visible.test.tsx packages/eclipsa/core/on-mount.test.tsx packages/eclipsa/core/watch.resume.test.tsx packages/eclipsa/core/resume.test.ts packages/eclipsa/core/runtime.test.ts packages/eclipsa/core/signal.test.ts packages/eclipsa/vite/compiler.test.ts`

## Notes
- `bun run typecheck` at the workspace root still fails in `@eclipsa/e2e` because `@babel/plugin-syntax-jsx` does not currently have a declaration file in this workspace setup.