### PR TITLE
fix: handle encoded route fallbacks and content exports

### DIFF
--- a/packages/content/vite.test.ts
+++ b/packages/content/vite.test.ts
@@ -180,6 +180,44 @@ export const posts = defineCollection({ loader: { load: () => [] } })
     expect(code).not.toContain('zod')
   })
 
+  it('stubs collections exported through an export list in the client environment', async () => {
+    const root = await createTempRoot()
+    const configPath = path.join(root, 'app', 'content.config.ts')
+    await fs.writeFile(
+      configPath,
+      `
+import { defineCollection } from '@eclipsa/content'
+
+const docs = defineCollection({ loader: { load: () => [] } })
+
+export { docs }
+`,
+    )
+    const plugin = getPlugin()
+    const configResolved =
+      typeof plugin.configResolved === 'function'
+        ? plugin.configResolved
+        : plugin.configResolved?.handler
+    await configResolved?.call(
+      {} as any,
+      {
+        root,
+      } as any,
+    )
+
+    const load = typeof plugin.load === 'function' ? plugin.load : plugin.load?.handler
+    const code = await load?.call(
+      {
+        environment: {
+          name: 'client',
+        },
+      } as any,
+      configPath,
+    )
+
+    expect(code).toContain('export const docs = Object.freeze')
+  })
+
   it('invalidates registered dev apps and emits a content HMR event for markdown changes', async () => {
     const root = await createTempRoot()
     const plugin = getPlugin()

--- a/packages/content/vite.ts
+++ b/packages/content/vite.ts
@@ -36,8 +36,27 @@ const getSearchAssetPath = (base: string) => {
 const isContentConfigId = (root: string, id: string) =>
   normalizeSlashes(path.resolve(stripQuery(id))) === normalizeSlashes(getConfigPath(root))
 
-const getNamedCollectionExports = (source: string) =>
-  [...source.matchAll(/^\s*export\s+const\s+([A-Za-z_$][\w$]*)\s*=/gm)].map((match) => match[1]!)
+const getNamedCollectionExports = (source: string) => {
+  const exportNames = new Set<string>()
+  for (const match of source.matchAll(/^\s*export\s+const\s+([A-Za-z_$][\w$]*)\s*=/gm)) {
+    exportNames.add(match[1]!)
+  }
+  for (const match of source.matchAll(
+    /^\s*export\s*\{([\s\S]*?)\}\s*(?:from\s*['"][^'"]+['"])?\s*;?/gm,
+  )) {
+    for (const rawSpecifier of match[1]!.split(',')) {
+      const specifier = rawSpecifier.trim()
+      if (!specifier || specifier.startsWith('type ')) {
+        continue
+      }
+      const parsed = /^([A-Za-z_$][\w$]*)(?:\s+as\s+([A-Za-z_$][\w$]*))?$/.exec(specifier)
+      if (parsed) {
+        exportNames.add(parsed[2] ?? parsed[1]!)
+      }
+    }
+  }
+  return [...exportNames]
+}
 
 const invalidateVirtualRuntime = (server: ViteDevServer) => {
   const graphs = [

--- a/packages/eclipsa/core/runtime/routes.test.ts
+++ b/packages/eclipsa/core/runtime/routes.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import type { RouteManifest } from '../router-shared.ts'
+import { findSpecialManifestEntry, matchRouteManifest } from './routes.ts'
+
+describe('runtime route manifest helpers', () => {
+  it('decodes url-encoded segments before matching manifest entries', () => {
+    const manifest: RouteManifest = [
+      {
+        error: null,
+        hasMiddleware: false,
+        layouts: [],
+        loading: null,
+        notFound: null,
+        page: '/entries/route__hello_world___slug____page.js',
+        routePath: '/hello world/[slug]',
+        segments: [
+          { kind: 'static', value: 'hello world' },
+          { kind: 'required', value: 'slug' },
+        ],
+        server: null,
+      },
+    ]
+
+    expect(matchRouteManifest(manifest, '/hello%20world/ada%20lovelace')).toMatchObject({
+      params: { slug: 'ada lovelace' },
+    })
+  })
+
+  it('keeps nearest dynamic params when resolving special manifest fallbacks', () => {
+    const manifest: RouteManifest = [
+      {
+        error: null,
+        hasMiddleware: false,
+        layouts: [],
+        loading: null,
+        notFound: '/entries/special__blog___slug____not_found.js',
+        page: '/entries/route__blog___slug____page.js',
+        routePath: '/blog/[slug]',
+        segments: [
+          { kind: 'static', value: 'blog' },
+          { kind: 'required', value: 'slug' },
+        ],
+        server: null,
+      },
+    ]
+
+    expect(findSpecialManifestEntry(manifest, '/blog/hello/missing', 'notFound')).toMatchObject({
+      params: { slug: 'hello' },
+    })
+  })
+})

--- a/packages/eclipsa/core/runtime/routes.ts
+++ b/packages/eclipsa/core/runtime/routes.ts
@@ -67,7 +67,18 @@ export const ROUTE_DOCUMENT_FALLBACK = Object.freeze({
   ok: false,
 } as const)
 
-const splitRoutePath = (pathname: string) => normalizeRoutePath(pathname).split('/').filter(Boolean)
+const decodeRoutePathSegment = (segment: string) => {
+  try {
+    return decodeURIComponent(segment)
+  } catch {
+    return segment
+  }
+}
+
+const splitRawRoutePath = (pathname: string) =>
+  normalizeRoutePath(pathname).split('/').filter(Boolean)
+
+const splitRoutePath = (pathname: string) => splitRawRoutePath(pathname).map(decodeRoutePathSegment)
 
 const matchRouteSegments = (
   segments: RouteModuleManifest['segments'],
@@ -172,9 +183,19 @@ export const findSpecialManifestEntry = (
   pathname: string,
   kind: 'error' | 'notFound',
 ) => {
-  const matched = matchRouteManifest(manifest, pathname)
+  const normalizedPath = normalizeRoutePath(pathname)
+  const matched = matchRouteManifest(manifest, normalizedPath)
   if (matched?.entry[kind]) {
     return matched
+  }
+
+  const rawPathSegments = splitRawRoutePath(normalizedPath)
+  for (let length = rawPathSegments.length - 1; length >= 0; length -= 1) {
+    const candidatePath = length === 0 ? '/' : `/${rawPathSegments.slice(0, length).join('/')}`
+    const candidate = matchRouteManifest(manifest, candidatePath)
+    if (candidate?.entry[kind]) {
+      return candidate
+    }
   }
 
   let best: ReturnType<typeof matchRouteManifest> = null
@@ -188,7 +209,7 @@ export const findSpecialManifestEntry = (
       best = {
         entry,
         params: EMPTY_ROUTE_PARAMS,
-        pathname: normalizeRoutePath(pathname),
+        pathname: normalizedPath,
       }
       bestScore = score
     }

--- a/packages/eclipsa/vite/build/mod.test.ts
+++ b/packages/eclipsa/vite/build/mod.test.ts
@@ -72,6 +72,7 @@ const writeMinimalRuntimeEntry = async (
     getNormalizedActionInputSource?: string
     hasActionSource?: string
     hasLoaderSource?: string
+    jsxDEVSource?: string
     renderSSRAsyncSource?: string
     renderSSRStreamSource?: string
     serializeResumePayloadSource?: string
@@ -98,7 +99,7 @@ const writeMinimalRuntimeEntry = async (
       options?.ensureActionCsrfTokenSource ?? 'export const ensureActionCsrfToken = () => "csrf";',
       options?.hasActionSource ?? 'export const hasAction = () => false;',
       options?.hasLoaderSource ?? 'export const hasLoader = () => false;',
-      'export const jsxDEV = () => ({});',
+      options?.jsxDEVSource ?? 'export const jsxDEV = () => ({});',
       options?.renderSSRAsyncSource ??
         'export const renderSSRAsync = async () => ({ html: "<html><head></head><body></body></html>", payload: {} });',
       options?.renderSSRStreamSource ??
@@ -731,6 +732,93 @@ describe('build', () => {
         missing: {
           data: null,
           error: { message: 'missing' },
+          loaded: true,
+        },
+      },
+      ok: true,
+    })
+  })
+
+  it('keeps nearest dynamic params when built not-found route-data fallbacks resolve encoded paths', async () => {
+    const root = await fs.mkdtemp(path.join(tmpdir(), 'eclipsa-build-not-found-params-'))
+    const builder = createBuilder()
+    await writeMinimalSsrEntries(root)
+    await writeMinimalRuntimeEntry(root, {
+      jsxDEVSource: 'export const jsxDEV = (type, props) => ({ type, props });',
+      renderSSRAsyncSource: [
+        'const resolveNode = (value) => {',
+        '  if (!value || typeof value !== "object") return value;',
+        '  if (typeof value.type === "function") return resolveNode(value.type(value.props ?? {}));',
+        '  return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, resolveNode(entry)]));',
+        '};',
+        'export const renderSSRAsync = async (renderDocument) => ({',
+        '  payload: {',
+        '    loaders: {',
+        '      params: {',
+        '        data: resolveNode(renderDocument()).params,',
+        '        error: null,',
+        '        loaded: true,',
+        '      },',
+        '    },',
+        '  },',
+        '});',
+      ].join('\n'),
+    })
+    await writeBuiltPageModule(
+      root,
+      'route__hello_world___slug____page',
+      'export default () => null;\n',
+    )
+    await writeBuiltPageModule(
+      root,
+      'special__hello_world___slug____not_found',
+      'export default (props) => ({ type: "not-found", params: props.__eclipsa_route_params });\n',
+    )
+    mocks.createRoutes.mockResolvedValue([
+      {
+        ...createRootRoute(),
+        notFound: {
+          entryName: 'special__hello_world___slug____not_found',
+          filePath: '/tmp/app/hello world/[slug]/+not-found.tsx',
+        },
+        page: {
+          entryName: 'route__hello_world___slug____page',
+          filePath: '/tmp/app/hello world/[slug]/+page.tsx',
+        },
+        routePath: '/hello world/[slug]',
+        segments: [
+          { kind: 'static', value: 'hello world' },
+          { kind: 'required', value: 'slug' },
+        ],
+        server: null,
+      },
+    ])
+
+    await build(builder, { root }, { output: 'node' })
+
+    const { default: app } = (await import(
+      `${pathToFileURL(path.join(root, 'dist/ssr/eclipsa_app.mjs')).href}?t=${Date.now()}`
+    )) as {
+      default: { fetch(request: Request): Promise<Response> }
+    }
+
+    const response = await app.fetch(
+      new Request(
+        'http://localhost/__eclipsa/route-data?href=http%3A%2F%2Flocalhost%2Fhello%2520world%2Fada%2Fmissing',
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      finalHref: 'http://localhost/hello%20world/ada/missing',
+      finalPathname: '/hello%20world/ada/missing',
+      kind: 'not-found',
+      loaders: {
+        params: {
+          data: {
+            slug: 'ada',
+          },
+          error: null,
           loaded: true,
         },
       },

--- a/packages/eclipsa/vite/build/mod.ts
+++ b/packages/eclipsa/vite/build/mod.ts
@@ -648,6 +648,18 @@ const normalizeRoutePath = (pathname) => {
     : withLeadingSlash;
 };
 
+const decodeRoutePathSegment = (segment) => {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+};
+
+const splitRawRoutePath = (pathname) => normalizeRoutePath(pathname).split("/").filter(Boolean);
+
+const splitRoutePath = (pathname) => splitRawRoutePath(pathname).map(decodeRoutePathSegment);
+
 const getRequestUrl = (request) => {
   const url = new URL(request.url);
   const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host");
@@ -714,7 +726,7 @@ const matchSegments = (segments, pathnameSegments, routeIndex = 0, pathIndex = 0
 };
 
 const matchRoute = (pathname) => {
-  const pathnameSegments = normalizeRoutePath(pathname).split("/").filter(Boolean);
+  const pathnameSegments = splitRoutePath(pathname);
   for (const route of routes) {
     const params = matchSegments(route.segments, pathnameSegments);
     if (params) {
@@ -725,7 +737,7 @@ const matchRoute = (pathname) => {
 };
 
 const matchRouteManifestEntry = (pathname) => {
-  const pathnameSegments = normalizeRoutePath(pathname).split("/").filter(Boolean);
+  const pathnameSegments = splitRoutePath(pathname);
   for (const entry of routeManifest) {
     const params = matchSegments(entry.segments, pathnameSegments);
     if (params) {
@@ -781,7 +793,7 @@ const createChunkCacheRegistrationScript = (pathname, payload) => {
 };
 
 const scoreSpecialRoute = (route, pathname) => {
-  const pathnameSegments = normalizeRoutePath(pathname).split("/").filter(Boolean);
+  const pathnameSegments = splitRoutePath(pathname);
   let score = 0;
   for (let index = 0; index < route.segments.length && index < pathnameSegments.length; index += 1) {
     const segment = route.segments[index];
@@ -802,9 +814,19 @@ const scoreSpecialRoute = (route, pathname) => {
 };
 
 const findSpecialRoute = (pathname, kind) => {
-  const matched = matchRoute(pathname);
+  const normalizedPath = normalizeRoutePath(pathname);
+  const matched = matchRoute(normalizedPath);
   if (matched?.route[kind]) {
     return matched;
+  }
+
+  const rawPathSegments = splitRawRoutePath(normalizedPath);
+  for (let length = rawPathSegments.length - 1; length >= 0; length -= 1) {
+    const candidatePath = length === 0 ? "/" : "/" + rawPathSegments.slice(0, length).join("/");
+    const candidate = matchRoute(candidatePath);
+    if (candidate?.route[kind]) {
+      return candidate;
+    }
   }
 
   let best = null;

--- a/packages/eclipsa/vite/dev-app/mod.test.ts
+++ b/packages/eclipsa/vite/dev-app/mod.test.ts
@@ -1651,6 +1651,121 @@ describe('createDevFetch', () => {
     })
   })
 
+  it('keeps nearest dynamic params when resolving not-found route-data fallbacks', async () => {
+    routes = [
+      {
+        error: null,
+        layouts: [],
+        loading: null,
+        middlewares: [],
+        notFound: {
+          entryName: 'special__hello_world___slug____not_found',
+          filePath: '/tmp/app/hello world/[slug]/+not-found.tsx',
+        },
+        page: {
+          entryName: 'route__hello_world___slug____page',
+          filePath: '/tmp/app/hello world/[slug]/+page.tsx',
+        },
+        routePath: '/hello world/[slug]',
+        segments: [
+          { kind: 'static', value: 'hello world' },
+          { kind: 'required', value: 'slug' },
+        ],
+        server: null,
+      },
+    ]
+
+    const devFetch = createDevFetch({
+      resolvedConfig: {
+        root: '/tmp',
+      } as any,
+      devServer: {} as any,
+      deps: {
+        collectAppActions,
+        collectAppLoaders,
+        collectAppSymbols,
+        createDevModuleUrl,
+        createDevSymbolUrl,
+        createRoutes,
+      },
+      runner: {
+        async import(id: string) {
+          if (id === '/app/+server-entry.ts') {
+            return { default: userApp }
+          }
+          if (id === '/tmp/app/hello world/[slug]/+not-found.tsx') {
+            return {
+              default(props: any) {
+                return {
+                  params: props.__eclipsa_route_params,
+                  type: 'not-found',
+                }
+              },
+            }
+          }
+          if (id === 'eclipsa') {
+            return {
+              renderSSRAsync(renderDocument: () => any) {
+                const resolveNode = (value: any): any => {
+                  if (!value || typeof value !== 'object') {
+                    return value
+                  }
+                  if (typeof value.type === 'function') {
+                    return resolveNode(value.type(value.props ?? {}))
+                  }
+                  return Object.fromEntries(
+                    Object.entries(value).map(([key, entry]) => [key, resolveNode(entry)]),
+                  )
+                }
+                return {
+                  payload: {
+                    loaders: {
+                      params: {
+                        data: resolveNode(renderDocument()).params,
+                        error: null,
+                        loaded: true,
+                      },
+                    },
+                  },
+                }
+              },
+              resolvePendingLoaders: vi.fn(),
+            }
+          }
+          return {
+            default() {
+              return null
+            },
+          }
+        },
+      } as any,
+      ssrEnv: {} as any,
+    })
+
+    const response = await devFetch.fetch(
+      new Request(
+        'http://localhost/__eclipsa/route-data?href=http%3A%2F%2Flocalhost%2Fhello%2520world%2Fada%2Fmissing',
+      ),
+    )
+
+    expect(response?.status).toBe(200)
+    await expect(response?.json()).resolves.toEqual({
+      finalHref: 'http://localhost/hello%20world/ada/missing',
+      finalPathname: '/hello%20world/ada/missing',
+      kind: 'not-found',
+      loaders: {
+        params: {
+          data: {
+            slug: 'ada',
+          },
+          error: null,
+          loaded: true,
+        },
+      },
+      ok: true,
+    })
+  })
+
   it('returns document fallback when route-data loader rendering throws notFound without a special route', async () => {
     const devFetch = createDevFetch({
       resolvedConfig: {

--- a/packages/eclipsa/vite/dev-app/mod.ts
+++ b/packages/eclipsa/vite/dev-app/mod.ts
@@ -335,7 +335,16 @@ const createRouteElement = (
 }
 
 const scoreSpecialRoute = (route: RouteEntry, pathname: string) => {
-  const pathnameSegments = normalizeRoutePath(pathname).split('/').filter(Boolean)
+  const pathnameSegments = normalizeRoutePath(pathname)
+    .split('/')
+    .filter(Boolean)
+    .map((segment) => {
+      try {
+        return decodeURIComponent(segment)
+      } catch {
+        return segment
+      }
+    })
   let score = 0
   for (
     let index = 0;
@@ -364,9 +373,19 @@ const findSpecialRoute = (
   pathname: string,
   kind: 'error' | 'notFound',
 ): { params: RouteParams; route: RouteEntry } | null => {
-  const matched = matchRoute(routes, pathname)
+  const normalizedPath = normalizeRoutePath(pathname)
+  const matched = matchRoute(routes, normalizedPath)
   if (matched?.route[kind]) {
     return matched
+  }
+
+  const rawPathSegments = normalizedPath.split('/').filter(Boolean)
+  for (let length = rawPathSegments.length - 1; length >= 0; length -= 1) {
+    const candidatePath = length === 0 ? '/' : `/${rawPathSegments.slice(0, length).join('/')}`
+    const candidate = matchRoute(routes, candidatePath)
+    if (candidate?.route[kind]) {
+      return candidate
+    }
   }
 
   let best: { params: RouteParams; route: RouteEntry } | null = null

--- a/packages/eclipsa/vite/utils/routing.test.ts
+++ b/packages/eclipsa/vite/utils/routing.test.ts
@@ -196,6 +196,30 @@ describe('routing helpers', () => {
     })
   })
 
+  it('decodes url-encoded path segments before matching routes', () => {
+    const routes: RouteEntry[] = [
+      {
+        error: null,
+        layouts: [],
+        loading: null,
+        middlewares: [],
+        notFound: null,
+        page: null,
+        routePath: '/hello world/[slug]',
+        segments: [
+          { kind: 'static', value: 'hello world' },
+          { kind: 'required', value: 'slug' },
+        ],
+        server: null,
+      },
+    ]
+
+    expect(matchRoute(routes, '/hello%20world/ada%20lovelace')).toMatchObject({
+      params: { slug: 'ada lovelace' },
+      route: routes[0],
+    })
+  })
+
   it('creates module manifests for dev and build route loading', () => {
     const routes: RouteEntry[] = [
       {

--- a/packages/eclipsa/vite/utils/routing.ts
+++ b/packages/eclipsa/vite/utils/routing.ts
@@ -55,6 +55,17 @@ interface RouteMatch<T> {
   route: T
 }
 
+const decodeRoutePathSegment = (segment: string) => {
+  try {
+    return decodeURIComponent(segment)
+  } catch {
+    return segment
+  }
+}
+
+const splitRoutePath = (pathname: string) =>
+  normalizeRoutePath(pathname).split('/').filter(Boolean).map(decodeRoutePathSegment)
+
 const createDirectoryEntry = (): RouteDirectoryEntry => ({
   error: null,
   layout: null,
@@ -278,7 +289,7 @@ const toMatch = <T extends { segments: RoutePathSegment[] }>(
   route: T,
   pathname: string,
 ): RouteMatch<T> | null => {
-  const pathnameSegments = normalizeRoutePath(pathname).split('/').filter(Boolean)
+  const pathnameSegments = splitRoutePath(pathname)
   const params = matchSegments(route.segments, pathnameSegments)
   if (!params) {
     return null


### PR DESCRIPTION
## Summary
- decode url-encoded route segments before matching route definitions in dev, build, and client runtime paths
- preserve nearest dynamic route params when resolving not-found and error fallbacks
- support `export { collection }` client stubs for `app/content.config.ts`

## Verification
- vp fmt
- vp lint
- vp run typecheck
- bun run test