### PR TITLE
Fix nested resumable symbol refs after HMR

### DIFF
--- a/packages/eclipsa/core/resume.test.ts
+++ b/packages/eclipsa/core/resume.test.ts
@@ -171,6 +171,26 @@ describe('resume HMR runtime helpers', () => {
         ['old-symbol', Promise.resolve({ default: () => null })],
         ['mid-symbol', Promise.resolve({ default: () => null })],
       ]),
+      scopes: new Map([
+        [
+          'sc0',
+          [
+            {
+              __eclipsa_type: 'ref',
+              data: [
+                {
+                  __eclipsa_type: 'ref',
+                  data: [],
+                  kind: 'symbol',
+                  token: 'old-symbol',
+                },
+              ],
+              kind: 'symbol',
+              token: 'old-symbol',
+            },
+          ],
+        ],
+      ]),
       symbols: new Map([['old-symbol', '/app/+page.tsx?eclipsa-symbol=old-symbol']]),
       visibles: new Map([
         [
@@ -216,6 +236,21 @@ describe('resume HMR runtime helpers', () => {
       'old-symbol': '/app/+page.tsx?eclipsa-symbol=mid-symbol',
     })
     expect(container.components.get('c0')?.symbol).toBe('mid-symbol')
+    expect(container.scopes.get('sc0')).toEqual([
+      {
+        __eclipsa_type: 'ref',
+        data: [
+          {
+            __eclipsa_type: 'ref',
+            data: [],
+            kind: 'symbol',
+            token: 'mid-symbol',
+          },
+        ],
+        kind: 'symbol',
+        token: 'mid-symbol',
+      },
+    ])
     expect(container.visibles.get('v0')?.symbol).toBe('mid-symbol')
     expect(container.watches.get('w0')?.symbol).toBe('mid-symbol')
     expect(collectResumeHmrBoundaryIds(container, ['mid-symbol'])).toEqual(['c0'])
@@ -228,6 +263,21 @@ describe('resume HMR runtime helpers', () => {
     expect(container.symbols.get('mid-symbol')).toBe('/app/+page.tsx?eclipsa-symbol=next-symbol')
     expect(container.symbols.get('next-symbol')).toBe('/app/+page.tsx?eclipsa-symbol=next-symbol')
     expect(container.components.get('c0')?.symbol).toBe('next-symbol')
+    expect(container.scopes.get('sc0')).toEqual([
+      {
+        __eclipsa_type: 'ref',
+        data: [
+          {
+            __eclipsa_type: 'ref',
+            data: [],
+            kind: 'symbol',
+            token: 'next-symbol',
+          },
+        ],
+        kind: 'symbol',
+        token: 'next-symbol',
+      },
+    ])
     expect(container.visibles.get('v0')?.symbol).toBe('next-symbol')
     expect(container.watches.get('w0')?.symbol).toBe('next-symbol')
     expect(collectResumeHmrBoundaryIds(container, ['next-symbol'])).toEqual(['c0'])

--- a/packages/eclipsa/core/runtime.ts
+++ b/packages/eclipsa/core/runtime.ts
@@ -6118,6 +6118,52 @@ export const collectResumeHmrBoundaryIds = (
   return result
 }
 
+const rewriteSerializedSymbolReferenceToken = (
+  value: SerializedValue,
+  affectedIds: ReadonlySet<string>,
+  nextSymbolId: string,
+) => {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      rewriteSerializedSymbolReferenceToken(entry, affectedIds, nextSymbolId)
+    }
+    return
+  }
+
+  if (!value || typeof value !== 'object' || !('__eclipsa_type' in value)) {
+    return
+  }
+
+  switch (value.__eclipsa_type) {
+    case 'object':
+      for (const [, entry] of value.entries) {
+        rewriteSerializedSymbolReferenceToken(entry, affectedIds, nextSymbolId)
+      }
+      return
+    case 'map':
+      for (const [key, entry] of value.entries) {
+        rewriteSerializedSymbolReferenceToken(key, affectedIds, nextSymbolId)
+        rewriteSerializedSymbolReferenceToken(entry, affectedIds, nextSymbolId)
+      }
+      return
+    case 'set':
+      for (const entry of value.entries) {
+        rewriteSerializedSymbolReferenceToken(entry, affectedIds, nextSymbolId)
+      }
+      return
+    case 'ref':
+      if (value.kind === 'symbol' && affectedIds.has(value.token)) {
+        value.token = nextSymbolId
+      }
+      if (value.data !== undefined) {
+        rewriteSerializedSymbolReferenceToken(value.data, affectedIds, nextSymbolId)
+      }
+      return
+    default:
+      return
+  }
+}
+
 export const applyResumeHmrSymbolReplacements = (
   container: RuntimeContainer,
   replacements: Record<string, string>,
@@ -6159,6 +6205,12 @@ export const applyResumeHmrSymbolReplacements = (
     for (const visible of container.visibles.values()) {
       if (affectedIds.has(visible.symbol)) {
         visible.symbol = nextSymbolId
+      }
+    }
+
+    for (const slots of container.scopes.values()) {
+      for (const slot of slots) {
+        rewriteSerializedSymbolReferenceToken(slot, affectedIds, nextSymbolId)
       }
     }
 


### PR DESCRIPTION
## Summary
- rewrite serialized `kind: "symbol"` refs stored in resumed scopes when HMR swaps symbol ids
- keep nested resumable callbacks pointing at the latest symbol token across repeated updates
- add a regression test covering scope-stored symbol refs during repeated HMR replacement

## Verification
- `/home/nakasyou/.bun/bin/bun run node_modules/@voidzero-dev/vite-plus-test/dist/cli.js packages/eclipsa/core/resume.test.ts --run`
- `/home/nakasyou/.bun/bin/bun run node_modules/@voidzero-dev/vite-plus-test/dist/cli.js packages/eclipsa --run`
- `/home/nakasyou/.bun/bin/bun run typecheck`
- `/home/nakasyou/.bun/bin/bun run lint` *(fails locally with repo-wide `vp check` `DataCloneError` unrelated to this change)*
- `/home/nakasyou/.bun/bin/bun run build` *(workspace build fails at existing `@eclipsa/e2e#build` config resolve error; `eclipsa` package build succeeds)*