### PR TITLE
Fix computed handles in resumable serialization

### DIFF
--- a/packages/eclipsa/core/internal.ts
+++ b/packages/eclipsa/core/internal.ts
@@ -61,6 +61,7 @@ export interface WatchMeta {
 export interface SignalMeta<T = unknown> {
   get(): T
   id: string
+  kind?: 'computed-signal' | 'signal'
   set(value: T): void
 }
 

--- a/packages/eclipsa/core/runtime.test.ts
+++ b/packages/eclipsa/core/runtime.test.ts
@@ -9696,6 +9696,70 @@ describe('renderClientInsertable', () => {
     })
   })
 
+  it('serializes computed handles as computed-signal references without losing computed semantics', () => {
+    withFakeNodeGlobal(() => {
+      const container = createContainer()
+      let count!: { value: number }
+      let computed!: { value: number }
+
+      const ComputedBody = () => {
+        count = useSignal(1)
+        computed = useComputed(() => count.value * 2, [count])
+        return 'ready'
+      }
+
+      const ComputedComponent = __eclipsaComponent(
+        ComputedBody,
+        'computed-serialization-component',
+        () => [],
+      )
+
+      withRuntimeContainer(container, () => {
+        const nodes = renderClientInsertable(
+          jsxDEV(ComputedComponent as any, {}, null, false, {}),
+          container,
+        )
+        const host = new FakeElement('div')
+        for (const node of nodes as FakeNode[]) {
+          host.appendChild(node)
+        }
+      })
+
+      const serialized = serializeContainerValue(container, {
+        computed,
+      })
+
+      expect(serialized).toEqual({
+        __eclipsa_type: 'object',
+        entries: [
+          [
+            'computed',
+            {
+              __eclipsa_type: 'ref',
+              kind: 'computed-signal',
+              token: 's1',
+            },
+          ],
+        ],
+      })
+
+      const restored = deserializeContainerValue(container, serialized as any) as {
+        computed: { value: number }
+      }
+
+      expect(restored.computed.value).toBe(2)
+
+      count.value = 3
+
+      expect(restored.computed.value).toBe(6)
+      expect(() =>
+        serializeContainerValue(container, {
+          computed: restored.computed,
+        }),
+      ).not.toThrow()
+    })
+  })
+
   it('repopulates keyed For ranges after clearing them', async () => {
     await withFakeNodeGlobal(async () => {
       const container = createContainer()

--- a/packages/eclipsa/core/runtime.ts
+++ b/packages/eclipsa/core/runtime.ts
@@ -1,7 +1,12 @@
 import type { JSX } from '../jsx/types.ts'
 import { FRAGMENT } from '../jsx/shared.ts'
 import { isSSRRawValue, isSSRTemplate } from '../jsx/jsx-dev-runtime.ts'
-import { isPendingSignalError, isSuspenseType, type SuspenseProps } from './suspense.ts'
+import {
+  createPendingSignalError,
+  isPendingSignalError,
+  isSuspenseType,
+  type SuspenseProps,
+} from './suspense.ts'
 import type { ResumeHmrUpdatePayload } from './resume-hmr.ts'
 import {
   ACTION_CSRF_FIELD,
@@ -642,6 +647,7 @@ const getRuntimeSerialization = () => {
     isRenderObject,
     isRouteSlot,
     loadSymbol,
+    materializeComputedSignalReference,
     materializeScope,
     materializeSymbolReference,
     registerScope,
@@ -678,9 +684,20 @@ const findNextNumericId = (ids: Iterable<string>, prefix: string) => {
   return nextId
 }
 
-const getRefSignalId = (value: unknown) => getSignalMeta(value)?.id ?? null
+const isWritableSignalMeta = (
+  meta: SignalMeta<unknown> | null,
+): meta is SignalMeta<unknown> & { kind?: 'signal' } =>
+  !!meta && meta.kind !== 'computed-signal'
 
-const getBindableSignalId = (value: unknown) => getSignalMeta(value)?.id ?? null
+const getRefSignalId = (value: unknown) => {
+  const signalMeta = getSignalMeta(value)
+  return isWritableSignalMeta(signalMeta) ? signalMeta.id : null
+}
+
+const getBindableSignalId = (value: unknown) => {
+  const signalMeta = getSignalMeta(value)
+  return isWritableSignalMeta(signalMeta) ? signalMeta.id : null
+}
 
 export const syncRuntimeRefMarker = (element: Element, value: unknown) => {
   const signalId = getRefSignalId(value)
@@ -706,7 +723,7 @@ export const assignRuntimeRef = (
   container: RuntimeContainer | null = getCurrentContainer(),
 ) => {
   const signalMeta = getSignalMeta<Element | undefined>(value)
-  if (!signalMeta) {
+  if (!isWritableSignalMeta(signalMeta)) {
     return false
   }
 
@@ -954,8 +971,60 @@ const createSignalHandle = <T>(record: SignalRecord<T>, container: RuntimeContai
   setSignalMeta(handle, {
     get: () => record.value,
     id: record.id,
+    kind: 'signal',
     set: (value) => {
       writeSignalValue(container, record, value)
+    },
+  } satisfies SignalMeta<T>)
+  return handle
+}
+
+interface ComputedSignalSnapshot<T> {
+  __e_async_computed: true
+  error?: unknown
+  promise?: Promise<T>
+  status: 'pending' | 'rejected' | 'resolved'
+  value?: T
+}
+
+const isComputedSignalSnapshot = <T>(
+  value: unknown,
+): value is ComputedSignalSnapshot<T> =>
+  !!value && typeof value === 'object' && (value as ComputedSignalSnapshot<T>).__e_async_computed === true
+
+const readComputedSignalValue = <T>(record: SignalRecord<unknown>) => {
+  recordSignalRead(record)
+  const snapshot = record.value
+  if (!isComputedSignalSnapshot<T>(snapshot)) {
+    return snapshot as T
+  }
+  if (snapshot.status === 'pending') {
+    throw createPendingSignalError(snapshot.promise ?? Promise.resolve(undefined))
+  }
+  if (snapshot.status === 'rejected') {
+    throw snapshot.error
+  }
+  return snapshot.value as T
+}
+
+const createComputedSignalHandle = <T>(
+  record: SignalRecord<unknown>,
+  _container: RuntimeContainer | null,
+) => {
+  const handle = {} as { value: T }
+  Object.defineProperty(handle, 'value', {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return readComputedSignalValue<T>(record)
+    },
+  })
+  setSignalMeta(handle, {
+    get: () => readComputedSignalValue<T>(record),
+    id: record.id,
+    kind: 'computed-signal',
+    set: () => {
+      throw new TypeError('Computed signals are read-only.')
     },
   } satisfies SignalMeta<T>)
   return handle
@@ -1309,6 +1378,14 @@ const materializeSymbolReference = (
     value: `eclipsa$${symbolId}`,
   })
   return fn
+}
+
+const materializeComputedSignalReference = (container: RuntimeContainer, signalId: string) => {
+  const record = container.signals.get(signalId)
+  if (!record) {
+    throw new Error(`Missing signal ${signalId}.`)
+  }
+  return createComputedSignalHandle(record, container)
 }
 
 const materializeScope = (container: RuntimeContainer, scopeId: string): unknown[] => {
@@ -7553,7 +7630,10 @@ export const createDetachedRuntimeSignal = <T>(
 ): { value: T } => ensureSignalRecord(container, id, fallback).handle
 
 export const getRuntimeComponentId = () => getCurrentFrame()?.component.id ?? null
-export const getRuntimeSignalId = (value: unknown) => getSignalMeta(value)?.id ?? null
+export const getRuntimeSignalId = (value: unknown) => {
+  const signalMeta = getSignalMeta(value)
+  return isWritableSignalMeta(signalMeta) ? signalMeta.id : null
+}
 
 export const useRuntimeNavigate = (): Navigate => {
   const container = getCurrentContainer()

--- a/packages/eclipsa/core/runtime.ts
+++ b/packages/eclipsa/core/runtime.ts
@@ -686,8 +686,7 @@ const findNextNumericId = (ids: Iterable<string>, prefix: string) => {
 
 const isWritableSignalMeta = (
   meta: SignalMeta<unknown> | null,
-): meta is SignalMeta<unknown> & { kind?: 'signal' } =>
-  !!meta && meta.kind !== 'computed-signal'
+): meta is SignalMeta<unknown> & { kind?: 'signal' } => !!meta && meta.kind !== 'computed-signal'
 
 const getRefSignalId = (value: unknown) => {
   const signalMeta = getSignalMeta(value)
@@ -987,10 +986,10 @@ interface ComputedSignalSnapshot<T> {
   value?: T
 }
 
-const isComputedSignalSnapshot = <T>(
-  value: unknown,
-): value is ComputedSignalSnapshot<T> =>
-  !!value && typeof value === 'object' && (value as ComputedSignalSnapshot<T>).__e_async_computed === true
+const isComputedSignalSnapshot = <T>(value: unknown): value is ComputedSignalSnapshot<T> =>
+  !!value &&
+  typeof value === 'object' &&
+  (value as ComputedSignalSnapshot<T>).__e_async_computed === true
 
 const readComputedSignalValue = <T>(record: SignalRecord<unknown>) => {
   recordSignalRead(record)

--- a/packages/eclipsa/core/runtime/serialization.ts
+++ b/packages/eclipsa/core/runtime/serialization.ts
@@ -57,6 +57,7 @@ interface RuntimeSerializationDependencies {
   isRenderObject: (value: unknown) => value is RenderObject
   isRouteSlot: (value: unknown) => value is RouteSlotValue
   loadSymbol: (container: RuntimeContainer, symbol: string) => Promise<unknown>
+  materializeComputedSignalReference: (container: RuntimeContainer, signalId: string) => unknown
   materializeScope: (container: RuntimeContainer, scopeId: string) => unknown[]
   materializeSymbolReference: (
     container: RuntimeContainer,
@@ -80,6 +81,7 @@ export const createRuntimeSerialization = ({
   isRenderObject,
   isRouteSlot,
   loadSymbol,
+  materializeComputedSignalReference,
   materializeScope,
   materializeSymbolReference,
   registerScope,
@@ -295,7 +297,7 @@ export const createRuntimeSerialization = ({
         if (signalMeta) {
           return {
             __eclipsa_type: 'ref',
-            kind: 'signal',
+            kind: signalMeta.kind === 'computed-signal' ? 'computed-signal' : 'signal',
             token: signalMeta.id,
           }
         }
@@ -490,6 +492,9 @@ export const createRuntimeSerialization = ({
             throw new Error(`Missing signal ${reference.token}.`)
           }
           return record.handle
+        }
+        if (reference.kind === 'computed-signal') {
+          return materializeComputedSignalReference(container, reference.token)
         }
         if (reference.kind === 'symbol') {
           if (!reference.data || !Array.isArray(reference.data)) {

--- a/packages/eclipsa/core/signal.ts
+++ b/packages/eclipsa/core/signal.ts
@@ -11,6 +11,7 @@ import {
   useRuntimeSignal,
   writeAsyncSignalSnapshot,
 } from './runtime.ts'
+import { setSignalMeta, type SignalMeta } from './internal.ts'
 import { createPendingSignalError, isPendingSignalError } from './suspense.ts'
 
 export interface Signal<T> {
@@ -174,6 +175,16 @@ const createComputedSignalFactory =
         return snapshot.value as T
       },
     })
+    if (signalId !== null) {
+      setSignalMeta(handle, {
+        get: () => handle.value,
+        id: signalId,
+        kind: 'computed-signal',
+        set: () => {
+          throw new TypeError('Computed signals are read-only.')
+        },
+      } satisfies SignalMeta<T>)
+    }
     return handle
   }
 


### PR DESCRIPTION
Closes #69

## Summary
- mark runtime `useComputed()` handles as dedicated `computed-signal` references instead of letting them fall through to plain accessor-object serialization
- restore computed handles with computed semantics during resume so `.value` still resolves snapshots, pending promises, and thrown errors correctly
- keep computed handles out of writable signal paths like ref binding and value binding, and add a regression test for computed capture serialization

## Verification
- `/home/nakasyou/.bun/bin/bun run node_modules/@voidzero-dev/vite-plus-test/dist/cli.js packages/eclipsa/core/runtime.test.ts packages/eclipsa/core/signal.test.ts --run`
- `/home/nakasyou/.bun/bin/bun run node_modules/@voidzero-dev/vite-plus-test/dist/cli.js packages/eclipsa --run`
- `/home/nakasyou/.bun/bin/bun run typecheck`