### PR TITLE
[codex] Fix docs build assets and search dialog rerenders

### DIFF
--- a/packages/eclipsa/core/runtime.test.ts
+++ b/packages/eclipsa/core/runtime.test.ts
@@ -1293,6 +1293,64 @@ describe('renderClientInsertable', () => {
     })
   })
 
+  it('preserves the runtime container when an insert rerender re-enters a local helper insert', async () => {
+    await withFakeNodeGlobal(async () => {
+      const container = createContainer()
+      const query = createDetachedRuntimeSignal(container, 's0', '')
+      const doc = container.doc as unknown as FakeDocument
+      const host = new FakeElement('div')
+      host.ownerDocument = doc
+      ;(doc.body as unknown as FakeElement).appendChild(host)
+
+      const SearchResultsBody = (props: { query: string }) => {
+        const body = doc.createElement('div') as FakeElement
+        insert(
+          (() =>
+            props.query.trim() === ''
+              ? 'Search titles, headings, content, and code.'
+              : jsxDEV(
+                  'a',
+                  {
+                    href: '/docs/getting-started/overview',
+                    children: 'Overview',
+                  },
+                  null,
+                  false,
+                  {},
+                )) as Parameters<typeof insert>[0],
+          body,
+        )
+        return body as unknown as JSX.Element
+      }
+
+      withRuntimeContainer(container, () => {
+        insert(
+          (() =>
+            jsxDEV(
+              'div',
+              {
+                children: [
+                  jsxDEV('input', { type: 'text', value: query.value }, null, false, {}),
+                  SearchResultsBody({ query: query.value }),
+                ],
+              },
+              null,
+              false,
+              {},
+            )) as Parameters<typeof insert>[0],
+          host as unknown as Node,
+        )
+      })
+
+      expect(host.textContent).toContain('Search titles, headings, content, and code.')
+
+      query.value = 'ov'
+      await flushAsync()
+
+      expect(host.textContent).toContain('Overview')
+    })
+  })
+
   it('keeps client insert refs attached to live elements across in-place patches', async () => {
     await withFakeNodeGlobal(async () => {
       const container = createContainer()

--- a/packages/eclipsa/core/runtime.ts
+++ b/packages/eclipsa/core/runtime.ts
@@ -1298,6 +1298,13 @@ const pushContainer = <T>(container: RuntimeContainer, fn: () => T): T => {
 
 export const withRuntimeContainer = pushContainer
 
+const runReactiveEffectInContainer = <T>(effect: ReactiveEffect, fn: () => T): T => {
+  if (!effect.container) {
+    return fn()
+  }
+  return pushContainer(effect.container, fn)
+}
+
 const withRuntimeContextValue = <T>(token: RuntimeContextToken, value: unknown, fn: () => T): T => {
   const stack = getContextValueStack()
   stack.push({
@@ -1519,6 +1526,7 @@ const getOrCreateWatchState = (
     return existing
   }
   const effect: ReactiveEffect = {
+    container,
     fn() {},
     signals: new Set(),
   }
@@ -7687,25 +7695,29 @@ export const isRouteNotFoundError = (error: unknown) =>
     (error as Record<PropertyKey, unknown>)[ROUTE_NOT_FOUND_KEY] === true)
 
 export const createEffect = (fn: () => void, options?: EffectOptions) => {
+  const container = getCurrentContainer()
   const frame = getCurrentFrame()
   const effect: ReactiveEffect = {
+    container,
     fn() {
-      const dependencies = options?.dependencies
-      if (!dependencies) {
-        collectTrackedDependencies(effect, fn)
-        return
-      }
+      runReactiveEffectInContainer(effect, () => {
+        const dependencies = options?.dependencies
+        if (!dependencies) {
+          collectTrackedDependencies(effect, fn)
+          return
+        }
 
-      collectTrackedDependencies(effect, () => {
-        trackWatchDependencies(dependencies, options?.errorLabel)
+        collectTrackedDependencies(effect, () => {
+          trackWatchDependencies(dependencies, options?.errorLabel)
+        })
+
+        if (options?.untracked) {
+          runWithoutDependencyTracking(fn)
+          return
+        }
+
+        fn()
       })
-
-      if (options?.untracked) {
-        runWithoutDependencyTracking(fn)
-        return
-      }
-
-      fn()
     },
     signals: new Set(),
   }
@@ -7769,8 +7781,11 @@ export const createWatch = (fn: () => void, dependencies?: WatchDependency[]) =>
   if (!container || !frame || frame.component.id === ROOT_COMPONENT_ID || !watchMeta) {
     const cleanupSlot = createCleanupSlot()
     const effect: ReactiveEffect = {
+      container,
       fn() {
-        createLocalWatchRunner(effect, cleanupSlot, fn, dependencies)()
+        runReactiveEffectInContainer(effect, () => {
+          createLocalWatchRunner(effect, cleanupSlot, fn, dependencies)()
+        })
       },
       signals: new Set(),
     }

--- a/packages/eclipsa/core/runtime/types.ts
+++ b/packages/eclipsa/core/runtime/types.ts
@@ -104,6 +104,7 @@ export interface StreamState {
 }
 
 export interface ReactiveEffect {
+  container?: RuntimeContainer | null
   fn: () => void
   signals: Set<SignalRecord>
 }

--- a/packages/eclipsa/vite/compiler.test.ts
+++ b/packages/eclipsa/vite/compiler.test.ts
@@ -8,6 +8,8 @@ import {
   collectAppActions,
   collectAppLoaders,
   collectAppSymbols,
+  createBuildSymbolEntryName,
+  createBuildSymbolUrl,
   compileModuleForSSR,
   createSymbolRequestId,
   createDevSymbolUrl,
@@ -523,6 +525,16 @@ describe('createResumeHmrUpdate', () => {
       filePath: '/app/+page.tsx',
       symbolId: 'symbol-123',
     })
+  })
+
+  it('creates URL-safe build symbol entry names for package symbols', () => {
+    expect(createBuildSymbolEntryName('symbol-123')).toBe('symbol__symbol-123')
+    expect(createBuildSymbolEntryName('@eclipsa/motion:motion')).toBe(
+      'symbol__b64_QGVjbGlwc2EvbW90aW9uOm1vdGlvbg',
+    )
+    expect(createBuildSymbolUrl('@eclipsa/motion:motion')).toBe(
+      '/entries/symbol__b64_QGVjbGlwc2EvbW90aW9uOm1vdGlvbg.js',
+    )
   })
 
   it('loads workspace motion symbol modules through the virtual symbol pipeline', async () => {

--- a/packages/eclipsa/vite/compiler.ts
+++ b/packages/eclipsa/vite/compiler.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import fg from 'fast-glob'
@@ -15,6 +16,7 @@ import type { ResumeHmrUpdatePayload } from '../core/resume-hmr.ts'
 
 const SYMBOL_QUERY = 'eclipsa-symbol'
 const SYMBOL_LANG_QUERY = 'lang.js'
+const SIMPLE_BUILD_SYMBOL_PATTERN = /^[A-Za-z0-9_-]+$/
 
 interface AnalyzedEntry {
   analyzed: AnalyzedModule
@@ -503,7 +505,13 @@ export const loadSymbolModuleForSSR = async (id: string) => {
 export const createDevSymbolUrl = (root: string, filePath: string, symbolId: string) =>
   createSymbolRequestId(createDevSourceUrl(root, filePath), symbolId)
 
-export const createBuildSymbolUrl = (symbolId: string) => `/entries/symbol__${symbolId}.js`
+export const createBuildSymbolEntryName = (symbolId: string) =>
+  SIMPLE_BUILD_SYMBOL_PATTERN.test(symbolId)
+    ? `symbol__${symbolId}`
+    : `symbol__b64_${Buffer.from(symbolId).toString('base64url')}`
+
+export const createBuildSymbolUrl = (symbolId: string) =>
+  `/entries/${createBuildSymbolEntryName(symbolId)}.js`
 
 export const createBuildServerActionUrl = (actionId: string) =>
   `../ssr/entries/action__${actionId}.mjs`

--- a/packages/eclipsa/vite/config.ts
+++ b/packages/eclipsa/vite/config.ts
@@ -9,6 +9,7 @@ import {
   collectAppActions,
   collectAppLoaders,
   collectAppSymbols,
+  createBuildSymbolEntryName,
   createSymbolRequestId,
 } from './compiler.ts'
 import type { ResolvedEclipsaPluginOptions } from './options.ts'
@@ -45,7 +46,7 @@ export const createConfig =
       ['client_boot', path.join(root, 'app/+client.dev.tsx')],
       ...(hasAppHooks ? [['app_hooks', appHooksPath] as const] : []),
       ...symbols.map((symbol) => [
-        `symbol__${symbol.id}`,
+        createBuildSymbolEntryName(symbol.id),
         createSymbolRequestId(symbol.filePath, symbol.id),
       ]),
       ...routeModules.map((entry) => [entry.entryName, entry.filePath]),

--- a/packages/image/mod.test.ts
+++ b/packages/image/mod.test.ts
@@ -5,6 +5,7 @@ import sharp from 'sharp'
 import { describe, expect, it } from 'vitest'
 import { Image } from './mod.ts'
 import {
+  createBuildAssetUrl,
   createAssetName,
   isAllowedImagePath,
   readLocalImage,
@@ -42,6 +43,10 @@ describe('@eclipsa/image helpers', () => {
     expect(createAssetName('/tmp/one/hero.png', 320, 'png')).not.toBe(
       createAssetName('/tmp/two/hero.png', 320, 'png'),
     )
+  })
+  it('creates public build asset URLs for emitted files', () => {
+    expect(createBuildAssetUrl('assets/example-320w.webp')).toBe('/assets/example-320w.webp')
+    expect(createBuildAssetUrl('/assets/example-320w.webp')).toBe('/assets/example-320w.webp')
   })
   it('only serves dev image paths inside the configured allowlist', async () => {
     const root = await fs.mkdtemp(path.join(tmpdir(), 'eclipsa-image-root-'))

--- a/packages/image/vite.ts
+++ b/packages/image/vite.ts
@@ -53,6 +53,7 @@ const splitId = (id: string) => {
 }
 
 const toOutputExtension = (format: string) => (format === 'jpeg' ? 'jpg' : format)
+export const createBuildAssetUrl = (fileName: string) => `/${fileName.replace(/^\/+/, '')}`
 
 export const toContentType = (format: string) => {
   if (format === 'svg') {
@@ -233,6 +234,7 @@ const createBuildModule = (
   variants: ImageVariantAsset[],
   filePath: string,
   emitFile: PluginContext['emitFile'],
+  emittedAssetReferenceIds: Set<string>,
 ) => {
   const references = variants.map((variant) =>
     emitFile({
@@ -242,6 +244,9 @@ const createBuildModule = (
       type: 'asset',
     }),
   )
+  for (const referenceId of references) {
+    emittedAssetReferenceIds.add(referenceId)
+  }
   const sourceIndex = variants.length - 1
 
   return `const variants = [
@@ -350,6 +355,7 @@ const writeDevImageResponse = async (
 
 export const eclipsaImage = (options: EclipsaImageOptions = {}): Plugin => {
   let config: ResolvedConfig | null = null
+  const emittedAssetReferenceIds = new Set<string>()
 
   return {
     configResolved(resolvedConfig) {
@@ -393,10 +399,21 @@ export const eclipsaImage = (options: EclipsaImageOptions = {}): Plugin => {
       )
 
       return config?.command === 'build'
-        ? createBuildModule(variants, resolved.filePath, this.emitFile.bind(this))
+        ? createBuildModule(
+            variants,
+            resolved.filePath,
+            this.emitFile.bind(this),
+            emittedAssetReferenceIds,
+          )
         : createDevModule(variants, resolved.filePath)
     },
     name: 'vite-plugin-eclipsa-image',
+    resolveFileUrl({ fileName, referenceId }) {
+      if (!emittedAssetReferenceIds.has(referenceId)) {
+        return null
+      }
+      return JSON.stringify(createBuildAssetUrl(fileName))
+    },
     async resolveId(source, importer) {
       const requested = parseImageRequest(source, options)
       if (!requested) {


### PR DESCRIPTION
## Summary
- make build-time symbol entry names URL-safe so package symbols like `@eclipsa/motion:motion` no longer 404 in docs builds
- fix `@eclipsa/image` asset URLs in SSR/static output so built docs stop embedding `file://` asset paths
- preserve the runtime container for reactive effect/watch reruns so docs search dialog updates can re-enter local helper inserts without crashing
- add regression coverage for the build URL helpers, image asset URLs, and the search dialog rerender path

## Root cause
- docs builds emitted symbol entry paths directly from symbol ids, which broke for package-style ids containing `/` and `:`
- the image plugin could resolve built asset URLs relative to the SSR output location instead of the public client asset root
- reactive insert reruns were executed without restoring the active runtime container, so nested helper inserts in the search dialog crashed on client updates

## Validation
- `vp build` in `docs`
- `vp fmt`
- `vp lint`
- `vp test --run mod.test.ts` in `packages/image`
- `vp test --run vite/compiler.test.ts` in `packages/eclipsa`
- `vp test --run core/runtime.test.ts` in `packages/eclipsa`
- headless browser verification against docs `dev` and built static output: opened search dialog, searched `motion`, got results, no console/page/request errors

## Notes
- `vp run typecheck` is still blocked in this environment by Turbo failing with `Unable to find package manager binary: cannot find binary path`
