### PR TITLE
Fix SSR image asset URLs

### DIFF
--- a/packages/image/mod.test.ts
+++ b/packages/image/mod.test.ts
@@ -49,7 +49,7 @@ describe('@eclipsa/image helpers', () => {
     expect(createBuildAssetUrl('assets/example-320w.webp')).toBe('/assets/example-320w.webp')
     expect(createBuildAssetUrl('/assets/example-320w.webp')).toBe('/assets/example-320w.webp')
   })
-  it('resolves emitted build asset references through the plugin hook', async () => {
+  it('inlines public build asset URLs in generated build modules', async () => {
     const root = await fs.mkdtemp(path.join(tmpdir(), 'eclipsa-image-build-'))
     const filePath = path.join(root, 'sample.png')
     await sharp({
@@ -71,32 +71,16 @@ describe('@eclipsa/image helpers', () => {
     } as never)
 
     const emitFile = vi.fn().mockReturnValue('image-ref')
-    await plugin.load?.call(
+    const moduleSource = await plugin.load?.call(
       { emitFile } as never,
       `\0eclipsa-image:${filePath}?eclipsa-image`,
       undefined,
     )
+    const sourceAssetFileName = `assets/${createAssetName(filePath, 900, 'png')}`
 
-    expect(
-      plugin.resolveFileUrl?.call({} as never, {
-        chunkId: 'chunk.js',
-        fileName: 'assets/sample-320w.webp',
-        format: 'es',
-        moduleId: filePath,
-        referenceId: 'image-ref',
-        relativePath: 'assets/sample-320w.webp',
-      }),
-    ).toBe(JSON.stringify('/assets/sample-320w.webp'))
-    expect(
-      plugin.resolveFileUrl?.call({} as never, {
-        chunkId: 'chunk.js',
-        fileName: 'assets/sample-320w.webp',
-        format: 'es',
-        moduleId: filePath,
-        referenceId: 'other-ref',
-        relativePath: 'assets/sample-320w.webp',
-      }),
-    ).toBeNull()
+    expect(emitFile).toHaveBeenCalled()
+    expect(moduleSource).toContain(JSON.stringify(createBuildAssetUrl(sourceAssetFileName)))
+    expect(moduleSource).not.toContain('ROLLUP_FILE_URL')
   })
   it('only serves dev image paths inside the configured allowlist', async () => {
     const root = await fs.mkdtemp(path.join(tmpdir(), 'eclipsa-image-root-'))

--- a/packages/image/vite.ts
+++ b/packages/image/vite.ts
@@ -42,19 +42,6 @@ type PluginContext = {
   }) => string
 }
 
-type ResolveFileUrlOptions = {
-  chunkId: string
-  fileName: string
-  format: string
-  moduleId: string
-  referenceId: string
-  relativePath: string
-}
-
-type ImagePlugin = Plugin & {
-  resolveFileUrl?: (options: ResolveFileUrlOptions) => string | null
-}
-
 const splitId = (id: string) => {
   const queryIndex = id.indexOf('?')
   return queryIndex === -1
@@ -247,36 +234,33 @@ const createBuildModule = (
   variants: ImageVariantAsset[],
   filePath: string,
   emitFile: PluginContext['emitFile'],
-  emittedAssetReferenceIds: Set<string>,
 ) => {
-  const references = variants.map((variant) =>
+  const entries = variants.map((variant) => {
+    const assetFileName = `assets/${createAssetName(filePath, variant.width, variant.format)}`
     emitFile({
-      fileName: `assets/${createAssetName(filePath, variant.width, variant.format)}`,
+      fileName: assetFileName,
       name: createAssetName(filePath, variant.width, variant.format),
       source: variant.buffer,
       type: 'asset',
-    }),
-  )
-  for (const referenceId of references) {
-    emittedAssetReferenceIds.add(referenceId)
-  }
+    })
+
+    return {
+      format: variant.format,
+      height: variant.height,
+      src: createBuildAssetUrl(assetFileName),
+      width: variant.width,
+    }
+  })
   const sourceIndex = variants.length - 1
 
-  return `const variants = [
-${variants
-  .map(
-    (variant, index) =>
-      `  { format: ${JSON.stringify(variant.format)}, height: ${variant.height}, src: import.meta.ROLLUP_FILE_URL_${references[index]}, width: ${variant.width} },`,
-  )
-  .join('\n')}
-];
+  return `const variants = ${JSON.stringify(entries)};
 
 export default {
-  format: ${JSON.stringify(variants[sourceIndex]!.format)},
-  height: ${variants[sourceIndex]!.height},
-  src: import.meta.ROLLUP_FILE_URL_${references[sourceIndex]!},
+  format: ${JSON.stringify(entries[sourceIndex]!.format)},
+  height: ${entries[sourceIndex]!.height},
+  src: ${JSON.stringify(entries[sourceIndex]!.src)},
   variants,
-  width: ${variants[sourceIndex]!.width},
+  width: ${entries[sourceIndex]!.width},
 };
 `
 }
@@ -368,9 +352,8 @@ const writeDevImageResponse = async (
 
 export const eclipsaImage = (options: EclipsaImageOptions = {}): Plugin => {
   let config: ResolvedConfig | null = null
-  const emittedAssetReferenceIds = new Set<string>()
 
-  const plugin: ImagePlugin = {
+  const plugin: Plugin = {
     configResolved(resolvedConfig) {
       config = resolvedConfig
     },
@@ -412,21 +395,10 @@ export const eclipsaImage = (options: EclipsaImageOptions = {}): Plugin => {
       )
 
       return config?.command === 'build'
-        ? createBuildModule(
-            variants,
-            resolved.filePath,
-            this.emitFile.bind(this),
-            emittedAssetReferenceIds,
-          )
+        ? createBuildModule(variants, resolved.filePath, this.emitFile.bind(this))
         : createDevModule(variants, resolved.filePath)
     },
     name: 'vite-plugin-eclipsa-image',
-    resolveFileUrl({ fileName, referenceId }) {
-      if (!emittedAssetReferenceIds.has(referenceId)) {
-        return null
-      }
-      return JSON.stringify(createBuildAssetUrl(fileName))
-    },
     async resolveId(source, importer) {
       const requested = parseImageRequest(source, options)
       if (!requested) {


### PR DESCRIPTION
## Summary
- stop emitting `import.meta.ROLLUP_FILE_URL_*` in `@eclipsa/image` build modules
- inline public `/assets/...` URLs so SSR output does not resolve images through `file://`
- update the image plugin test to assert public URLs are embedded in the generated module

## Verification
- vp build
- vp test run packages/image/mod.test.ts
- vp lint
- vp fmt
- vp exec tsc -p tsconfig.json --noEmit
- vp exec --filter ./docs tsgo -p tsconfig.json --noEmit

## Notes
- `vp run typecheck` failed in this environment because Turbo could not resolve the package manager binary, so I ran equivalent direct type checks instead.