### PR TITLE
Fix CodeQL after native Compose merge

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       # The Android Compose host introduces Kotlin sources, but the repository
       # does not yet provision an Android SDK in CI. Keeping CodeQL scoped to

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: 'Code Quality: CodeQL'
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: codeql-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # The Android Compose host introduces Kotlin sources, but the repository
+      # does not yet provision an Android SDK in CI. Keeping CodeQL scoped to
+      # JavaScript/TypeScript avoids breaking the default branch until a
+      # dedicated Android/Kotlin analysis job is added.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:javascript-typescript


### PR DESCRIPTION
## Summary
- add an explicit CodeQL workflow for JavaScript/TypeScript
- avoid the default java-kotlin analysis path that now fails on the Android Compose host sources
- document in the workflow why Kotlin scanning should return only after Android SDK-backed CI exists

## Testing
- `vp fmt`
- `vp lint`
- `nix shell nixpkgs#gcc nixpkgs#gnumake -c bash -lc 'cd /home/nakasyou/Projects/eclipsa && bun run --cwd packages/optimizer build:native:dev && ./node_modules/.bin/vp run typecheck'`
- `bun test packages/native-compose/mod.test.ts packages/native-compose/host.test.ts packages/native-compose/vite.test.ts`
