### PR TITLE
fix: harden SSR raw marker against object forgery

### DIFF
--- a/packages/eclipsa/core/ssr-raw.test.ts
+++ b/packages/eclipsa/core/ssr-raw.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { jsxDEV, ssrRaw } from '../jsx/jsx-dev-runtime.ts'
+import { renderSSR } from './ssr.ts'
+
+describe('ssrRaw', () => {
+  it('renders framework-created SSR raw values as unescaped HTML', () => {
+    const { html } = renderSSR(() =>
+      jsxDEV('div', { children: ssrRaw('<span>safe</span>') }, null, false, {}),
+    )
+
+    expect(html).toBe('<div><span>safe</span></div>')
+  })
+
+  it('ignores forged raw markers from untrusted plain objects', () => {
+    const forged = {
+      __e_ssr_raw: true,
+      value: '<img src=x onerror=alert(1)>',
+    }
+
+    const { html } = renderSSR(() => jsxDEV('div', { children: forged }, null, false, {}))
+
+    expect(html).toBe('<div></div>')
+    expect(html).not.toContain('<img')
+  })
+})

--- a/packages/eclipsa/jsx/jsx-dev-runtime.ts
+++ b/packages/eclipsa/jsx/jsx-dev-runtime.ts
@@ -11,6 +11,7 @@ export interface SSRRawValue {
   __e_ssr_raw: true
   value: string
 }
+const SSR_RAW_BRAND = Symbol('eclipsa.ssr.raw')
 
 export const jsxDEV = (
   type: JSX.Type,
@@ -35,13 +36,24 @@ export const ssrAttr = (name: string, value: unknown): SSRAttrValue => ({
 export const isSSRAttrValue = (value: unknown): value is SSRAttrValue =>
   !!value && typeof value === 'object' && (value as SSRAttrValue).__e_ssr_attr === true
 
-export const ssrRaw = (value: string): JSX.SSRRaw => ({
-  __e_ssr_raw: true,
-  value,
-})
+export const ssrRaw = (value: string): JSX.SSRRaw =>
+  Object.defineProperty(
+    {
+      __e_ssr_raw: true,
+      value,
+    },
+    SSR_RAW_BRAND,
+    {
+      value: true,
+    },
+  ) as JSX.SSRRaw
 
 export const isSSRRawValue = (value: unknown): value is SSRRawValue =>
-  !!value && typeof value === 'object' && (value as SSRRawValue).__e_ssr_raw === true
+  !!value &&
+  typeof value === 'object' &&
+  (value as SSRRawValue).__e_ssr_raw === true &&
+  typeof (value as SSRRawValue).value === 'string' &&
+  (value as { [SSR_RAW_BRAND]?: unknown })[SSR_RAW_BRAND] === true
 
 export const ssrTemplate = (strings: readonly string[], ...values: unknown[]): JSX.SSRTemplate => ({
   __e_ssr_template: true,


### PR DESCRIPTION
### Motivation
- The SSR fast-path treated any object with `__e_ssr_raw: true` as trusted raw HTML, allowing attacker-controlled plain objects/JSON to bypass escaping and cause XSS. 
- The intention is to preserve framework-provided `ssrRaw(...)` semantics while preventing untrusted objects from being interpreted as trusted raw HTML.

### Description
- Introduce an internal symbol brand `SSR_RAW_BRAND` and attach it to `ssrRaw(...)` values using `Object.defineProperty` so the marker cannot be forged by plain objects. 
- Strengthen `isSSRRawValue` to require the legacy `__e_ssr_raw` marker, a string `value`, and the internal `SSR_RAW_BRAND` before treating a value as trusted raw HTML. 
- Add a regression test `packages/eclipsa/core/ssr-raw.test.ts` that verifies framework-created `ssrRaw(...)` still renders unescaped while forged `{ __e_ssr_raw: true }` objects are ignored.

### Testing
- Ran a runtime sanity check with `bun -e` that prints `renderSSRValue(ssrRaw('<b>x</b>'))` as trusted HTML and shows a forged object is not treated as raw (observed trusted output and empty/escaped forged output). 
- Added a unit test `packages/eclipsa/core/ssr-raw.test.ts` to cover both trusted and forged cases; running `bun run test --filter=ssr-raw` could not be executed in this environment due to missing workspace tooling (`turbo`), so the test file is present but full test-suite execution was not completed. 
- Lint/format/typecheck scripts (`vp lint`, `vp fmt`, `vp run typecheck`) could not be run in this environment because the `vp` tool is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df0f10d94c8332951c740fe9edc7b0)