### PR TITLE
fix(vite): apply server hooks to built page routes

### DIFF
--- a/packages/eclipsa/vite/build/mod.test.ts
+++ b/packages/eclipsa/vite/build/mod.test.ts
@@ -630,6 +630,70 @@ describe('build', () => {
     expect(blockedResponse.status).toBe(404)
   })
 
+  it('runs server hooks for built page route requests', async () => {
+    const root = await fs.mkdtemp(path.join(tmpdir(), 'eclipsa-build-page-hooks-'))
+    const builder = createBuilder()
+    const secureServerPath = await writeAppSource(root, 'secure/[id]/+server.ts')
+    await writeAppSource(
+      root,
+      '+hooks.server.ts',
+      'export const handle = async (_c, resolve) => resolve(_c);\n',
+    )
+    await writeMinimalSsrEntries(root)
+    await writeMinimalRuntimeEntry(root)
+    await writeBuiltPageModule(
+      root,
+      'route__secure___id___server',
+      'export default (c) => c.json({ handled: c.get("fromHandle") ?? null, id: c.req.param("id") ?? null });\n',
+    )
+    await writeBuiltPageModule(
+      root,
+      'special__secure__middleware',
+      'export default async (c, next) => { c.set("guard", "secure"); await next(); };\n',
+    )
+    await writeBuiltPageModule(
+      root,
+      'server_hooks',
+      'export const handle = async (c, resolve) => { c.set("fromHandle", "yes"); return resolve(c); };\n',
+    )
+    mocks.createRoutes.mockResolvedValue([
+      {
+        ...createRootRoute(),
+        middlewares: [
+          {
+            entryName: 'special__secure__middleware',
+            filePath: path.join(root, 'app/secure/+middleware.ts'),
+          },
+        ],
+        page: null,
+        routePath: '/secure/[id]',
+        segments: [
+          { kind: 'static', value: 'secure' },
+          { kind: 'required', value: 'id' },
+        ],
+        server: {
+          entryName: 'route__secure___id___server',
+          filePath: secureServerPath,
+        },
+      },
+    ])
+
+    await build(builder, { root }, { output: 'node' })
+
+    const { default: app } = (await import(
+      `${pathToFileURL(path.join(root, 'dist/ssr/eclipsa_app.mjs')).href}?t=${Date.now()}`
+    )) as {
+      default: { fetch(request: Request): Promise<Response> }
+    }
+
+    const response = await app.fetch(new Request('http://localhost/secure/123'))
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      handled: 'yes',
+      id: '123',
+    })
+  })
+
   it('rejects built form posts that target actions outside the current route graph', async () => {
     const root = await fs.mkdtemp(path.join(tmpdir(), 'eclipsa-build-form-action-'))
     const builder = createBuilder()

--- a/packages/eclipsa/vite/build/mod.ts
+++ b/packages/eclipsa/vite/build/mod.ts
@@ -1442,24 +1442,26 @@ const resolveRoutePreflight = async (href, c) => {
 };
 
 for (const pageRouteEntry of pageRouteEntries) {
-  app.get(pageRouteEntry.path, async (c) => {
-    const pathname = normalizeRoutePath(getRequestUrl(c.req.raw).pathname);
-    const match = matchRoute(pathname);
-    if (!match || match.route !== routes[pageRouteEntry.routeIndex]) {
-      return c.text("Not Found", 404);
-    }
-    return composeRouteMiddlewares(
-      match.route,
-      c,
-      match.params,
-      async () =>
-        c.req.header(ROUTE_PREFLIGHT_REQUEST_HEADER) === "1"
-          ? c.body(null, 204)
-          : c.req.header(ROUTE_DATA_REQUEST_HEADER) === "1"
-            ? renderRouteData(match.route, pathname, match.params, c, match.route.page, "page")
-            : renderMatchedPage(match, c),
-    );
-  });
+  app.get(pageRouteEntry.path, async (c) =>
+    resolveRequest(c, async (requestContext) => {
+      const pathname = normalizeRoutePath(getRequestUrl(requestContext.req.raw).pathname);
+      const match = matchRoute(pathname);
+      if (!match || match.route !== routes[pageRouteEntry.routeIndex]) {
+        return requestContext.text("Not Found", 404);
+      }
+      return composeRouteMiddlewares(
+        match.route,
+        requestContext,
+        match.params,
+        async () =>
+          requestContext.req.header(ROUTE_PREFLIGHT_REQUEST_HEADER) === "1"
+            ? requestContext.body(null, 204)
+            : requestContext.req.header(ROUTE_DATA_REQUEST_HEADER) === "1"
+              ? renderRouteData(match.route, pathname, match.params, requestContext, match.route.page, "page")
+              : renderMatchedPage(match, requestContext),
+      );
+    }),
+  );
 }
 
 app.post("/__eclipsa/action/:id", async (c) =>
@@ -1522,88 +1524,93 @@ app.get("/__eclipsa/loader/:id", async (c) =>
   }),
 );
 
-app.get(${JSON.stringify(ROUTE_PREFLIGHT_ENDPOINT)}, async (c) => {
-  const href = c.req.query("href");
-  if (!href) {
-    return c.json({ document: true, ok: false }, 400);
-  }
-  return resolveRoutePreflight(href, c);
-});
+app.get(${JSON.stringify(ROUTE_PREFLIGHT_ENDPOINT)}, async (c) =>
+  resolveRequest(c, async (requestContext) => {
+    const href = requestContext.req.query("href");
+    if (!href) {
+      return requestContext.json({ document: true, ok: false }, 400);
+    }
+    return resolveRoutePreflight(href, requestContext);
+  }),
+);
 
-app.get(${JSON.stringify(ROUTE_DATA_ENDPOINT)}, async (c) => {
-  const href = c.req.query("href");
-  if (!href) {
-    return c.json({ document: true, ok: false }, 400);
-  }
-  return resolveRouteData(href, c);
-});
+app.get(${JSON.stringify(ROUTE_DATA_ENDPOINT)}, async (c) =>
+  resolveRequest(c, async (requestContext) => {
+    const href = requestContext.req.query("href");
+    if (!href) {
+      return requestContext.json({ document: true, ok: false }, 400);
+    }
+    return resolveRouteData(href, requestContext);
+  }),
+);
 
-app.all("*", async (c) => {
-  const pathname = normalizeRoutePath(getRequestUrl(c.req.raw).pathname);
-  const match = matchRoute(pathname);
+app.all("*", async (c) =>
+  resolveRequest(c, async (requestContext) => {
+    const pathname = normalizeRoutePath(getRequestUrl(requestContext.req.raw).pathname);
+    const match = matchRoute(pathname);
 
   if (!match) {
     const fallback = findSpecialRoute(pathname, "notFound");
     if (fallback?.route?.notFound) {
       return composeRouteMiddlewares(
         fallback.route,
-        c,
+        requestContext,
         fallback.params,
         async () =>
-          c.req.header(ROUTE_PREFLIGHT_REQUEST_HEADER) === "1"
-          ? c.body(null, 204)
-          : c.req.header(ROUTE_DATA_REQUEST_HEADER) === "1"
-              ? renderRouteData(fallback.route, pathname, fallback.params, c, fallback.route.notFound, "not-found")
-              : renderRouteResponse(fallback.route, pathname, fallback.params, c, fallback.route.notFound, 404),
+          requestContext.req.header(ROUTE_PREFLIGHT_REQUEST_HEADER) === "1"
+          ? requestContext.body(null, 204)
+          : requestContext.req.header(ROUTE_DATA_REQUEST_HEADER) === "1"
+              ? renderRouteData(fallback.route, pathname, fallback.params, requestContext, fallback.route.notFound, "not-found")
+              : renderRouteResponse(fallback.route, pathname, fallback.params, requestContext, fallback.route.notFound, 404),
       );
     }
-    return c.text("Not Found", 404);
+    return requestContext.text("Not Found", 404);
   }
 
-  if ((c.req.method === "GET" || c.req.method === "HEAD") && match.route.page) {
+  if ((requestContext.req.method === "GET" || requestContext.req.method === "HEAD") && match.route.page) {
     return composeRouteMiddlewares(
       match.route,
-      c,
+      requestContext,
       match.params,
         async () =>
-          c.req.header(ROUTE_PREFLIGHT_REQUEST_HEADER) === "1"
-            ? c.body(null, 204)
-            : c.req.header(ROUTE_DATA_REQUEST_HEADER) === "1"
-              ? renderRouteData(match.route, pathname, match.params, c, match.route.page, "page")
-              : renderMatchedPage(match, c),
+          requestContext.req.header(ROUTE_PREFLIGHT_REQUEST_HEADER) === "1"
+            ? requestContext.body(null, 204)
+            : requestContext.req.header(ROUTE_DATA_REQUEST_HEADER) === "1"
+              ? renderRouteData(match.route, pathname, match.params, requestContext, match.route.page, "page")
+              : renderMatchedPage(match, requestContext),
     );
   }
-  if (c.req.method === "POST" && match.route.page) {
+  if (requestContext.req.method === "POST" && match.route.page) {
     return composeRouteMiddlewares(
       match.route,
-      c,
+      requestContext,
       match.params,
       async () => {
-        const actionId = await getActionFormSubmissionId(c);
+        const actionId = await getActionFormSubmissionId(requestContext);
         if (!actionId) {
           return match.route.server
-            ? invokeRouteServer(match.route.server, c, match.params)
-            : renderMatchedPage(match, c);
+            ? invokeRouteServer(match.route.server, requestContext, match.params)
+            : renderMatchedPage(match, requestContext);
         }
         const routeAccess = getRouteServerAccess(match.route);
         if (!routeAccess.actionIds.includes(actionId)) {
-          return c.text("Not Found", 404);
+          return requestContext.text("Not Found", 404);
         }
         const moduleUrl = actions[actionId];
         if (!moduleUrl) {
-          return c.text("Not Found", 404);
+          return requestContext.text("Not Found", 404);
         }
         if (!hasAction(actionId)) {
           await import(moduleUrl);
         }
-        const input = await getNormalizedActionInput(c);
-        const response = await executeAction(actionId, c);
+        const input = await getNormalizedActionInput(requestContext);
+        const response = await executeAction(actionId, requestContext);
         const contentType = response.headers.get("content-type") ?? "";
         if (!contentType.startsWith(ACTION_CONTENT_TYPE)) {
           return response;
         }
         const body = await response.json();
-        return renderMatchedPage(match, c, {
+        return renderMatchedPage(match, requestContext, {
           prepare(container) {
             primeActionState(container, actionId, {
               error: body.ok ? undefined : deserializeValue(body.error),
@@ -1616,23 +1623,24 @@ app.all("*", async (c) => {
     );
   }
   if (match.route.server) {
-    return composeRouteMiddlewares(match.route, c, match.params, async () =>
-      invokeRouteServer(match.route.server, c, match.params),
+    return composeRouteMiddlewares(match.route, requestContext, match.params, async () =>
+      invokeRouteServer(match.route.server, requestContext, match.params),
     );
   }
   if (match.route.page) {
     return composeRouteMiddlewares(
       match.route,
-      c,
+      requestContext,
       match.params,
       async () =>
-        c.req.header(ROUTE_PREFLIGHT_REQUEST_HEADER) === "1"
-          ? c.body(null, 204)
-          : renderMatchedPage(match, c),
+        requestContext.req.header(ROUTE_PREFLIGHT_REQUEST_HEADER) === "1"
+          ? requestContext.body(null, 204)
+          : renderMatchedPage(match, requestContext),
     );
   }
-  return c.text("Not Found", 404);
-});
+    return requestContext.text("Not Found", 404);
+  }),
+);
 
 export const pageRoutePatterns = [...new Set(pageRouteEntries.map((entry) => entry.path))];
 export default app;


### PR DESCRIPTION
### Motivation
- Production build handlers were invoking action/loader/page logic with raw Hono contexts, skipping `resolveRequest` and therefore bypassing `serverHooks.handle` and request context setup.
- This allowed apps that rely on `handle` for auth/authorization/security to be bypassed in production.

### Description
- Wrap built page-route `app.get` handlers with `resolveRequest` so `serverHooks.handle` and request context are applied before matching and rendering.
- Wrap built `ROUTE_PREFLIGHT_ENDPOINT` and `ROUTE_DATA_ENDPOINT` handlers with `resolveRequest` for parity with the dev server behavior.
- Wrap the built catch-all (`app.all('*')`) handler with `resolveRequest` and thread the produced `requestContext` through fallbacks, page/server/action flows, and middleware invocations.
- Add a regression test `it('runs server hooks for built page route requests')` to `packages/eclipsa/vite/build/mod.test.ts` that verifies `+hooks.server.ts` `handle` runs for built page route (`+server`) requests.

### Testing
- Added a regression unit test `runs server hooks for built page route requests` in `packages/eclipsa/vite/build/mod.test.ts`; the test was added but could not be executed end-to-end in this environment.
- Attempted `vp lint`, `vp fmt`, and `vp run typecheck` but `vp` is not available in the environment, so these checks were not run.
- Attempted to run the test target with `bun run test` and `bunx vitest` but the environment lacked `turbo` and remote registry access returned `403`, so automated tests could not be completed here.
- Local test artifacts and the new regression test are included in the change for CI to validate in a full environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df1150e898833291fed501bc3275ba)