### PR TITLE
Harden ssrRaw against forged objects

### DIFF
--- a/packages/eclipsa/core/ssr-fast-path.test.ts
+++ b/packages/eclipsa/core/ssr-fast-path.test.ts
@@ -1,7 +1,8 @@
 import { Fragment, jsxDEV } from 'eclipsa/jsx-dev-runtime'
 import { describe, expect, it } from 'vitest'
-import { ssrAttr, ssrTemplate } from '../jsx/jsx-dev-runtime.ts'
+import { ssrAttr, ssrRaw, ssrTemplate } from '../jsx/jsx-dev-runtime.ts'
 import { renderSSR } from './ssr.ts'
+
 describe('SSR fast path helpers', () => {
   it('renders dynamic attributes and children through ssrTemplate', () => {
     const View = (props) =>
@@ -55,5 +56,15 @@ describe('SSR fast path helpers', () => {
     expect(html).toContain('<div>template</div>')
     expect(html).toContain('<div>jsx</div>')
     expect(html).not.toContain(' key=')
+  })
+
+  it('renders only helper-created ssrRaw values as trusted HTML', () => {
+    const trusted = ssrRaw('<span>trusted</span>')
+    const forged = { ...trusted, value: '<img src=x onerror="alert(1)" />' }
+
+    const { html } = renderSSR(() => ssrTemplate(['<div>', '', '</div>'], trusted, forged))
+
+    expect(html).toBe('<div><span>trusted</span></div>')
+    expect(html).not.toContain('onerror')
   })
 })

--- a/packages/eclipsa/jsx/jsx-dev-runtime.ts
+++ b/packages/eclipsa/jsx/jsx-dev-runtime.ts
@@ -12,6 +12,8 @@ export interface SSRRawValue {
   value: string
 }
 
+const SSR_RAW_VALUES = new WeakSet<SSRRawValue>()
+
 export const jsxDEV = (
   type: JSX.Type,
   props: Record<string, unknown>,
@@ -35,13 +37,17 @@ export const ssrAttr = (name: string, value: unknown): SSRAttrValue => ({
 export const isSSRAttrValue = (value: unknown): value is SSRAttrValue =>
   !!value && typeof value === 'object' && (value as SSRAttrValue).__e_ssr_attr === true
 
-export const ssrRaw = (value: string): JSX.SSRRaw => ({
-  __e_ssr_raw: true,
-  value,
-})
+export const ssrRaw = (value: string): JSX.SSRRaw => {
+  const rawValue: SSRRawValue = {
+    __e_ssr_raw: true,
+    value,
+  }
+  SSR_RAW_VALUES.add(rawValue)
+  return rawValue
+}
 
 export const isSSRRawValue = (value: unknown): value is SSRRawValue =>
-  !!value && typeof value === 'object' && (value as SSRRawValue).__e_ssr_raw === true
+  !!value && typeof value === 'object' && SSR_RAW_VALUES.has(value as SSRRawValue)
 
 export const ssrTemplate = (strings: readonly string[], ...values: unknown[]): JSX.SSRTemplate => ({
   __e_ssr_template: true,


### PR DESCRIPTION
## Summary
- harden `ssrRaw` so only helper-created values are treated as trusted HTML during SSR
- add a regression test proving forged plain objects no longer bypass escaping/raw handling

## Root cause
SSR raw values were identified by a forgeable `__e_ssr_raw` property, so attacker-controlled objects could masquerade as trusted HTML.

## Verification
- `bunx vp lint`
- `bunx vp fmt`
- `bunx vp run typecheck`
- `bun run --filter=./packages/eclipsa test`
