### PR TITLE
fix: enforce route-scoped auth for realtime RPC

### DIFF
--- a/packages/eclipsa/core/realtime.test.ts
+++ b/packages/eclipsa/core/realtime.test.ts
@@ -12,6 +12,7 @@ import {
 } from './realtime.ts'
 import type { RuntimeContainer } from './runtime.ts'
 import { withRuntimeContainer } from './runtime.ts'
+import { ROUTE_RPC_URL_QUERY } from './router-shared.ts'
 
 class FakeSocket implements RealtimeSocketLike {
   listeners = new Map<string, Array<(event: any) => void>>()
@@ -189,6 +190,7 @@ describe('realtime runtime', () => {
   it('connects client handles with WebSocket transport and records messages', () => {
     const sockets: FakeBrowserWebSocket[] = []
     const OriginalWebSocket = globalThis.WebSocket
+    const OriginalWindow = (globalThis as { window?: unknown }).window
 
     class FakeBrowserWebSocket extends EventTarget {
       static CONNECTING = 0
@@ -226,6 +228,14 @@ describe('realtime runtime', () => {
     }
 
     globalThis.WebSocket = FakeBrowserWebSocket as unknown as typeof WebSocket
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        location: {
+          href: 'http://localhost/current?tab=chat',
+        },
+      },
+    })
 
     try {
       const container = createRuntimeContainer()
@@ -241,6 +251,9 @@ describe('realtime runtime', () => {
       room.connect({ room: 'main' })
       expect(room.status).toBe('connecting')
       expect(sockets[0]?.url).toContain('/__eclipsa/realtime/client-room')
+      expect(new URL(sockets[0]!.url).searchParams.get(ROUTE_RPC_URL_QUERY)).toBe(
+        'http://localhost/current?tab=chat',
+      )
 
       sockets[0]!.open()
       expect(room.isOpen).toBe(true)
@@ -260,6 +273,10 @@ describe('realtime runtime', () => {
       expect(room.messages).toEqual([{ text: 'world' }])
     } finally {
       globalThis.WebSocket = OriginalWebSocket
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: OriginalWindow,
+      })
     }
   })
 })

--- a/packages/eclipsa/core/realtime.ts
+++ b/packages/eclipsa/core/realtime.ts
@@ -8,6 +8,7 @@ import {
   transformCurrentPublicError,
   type WithAppEnv,
 } from './hooks.ts'
+import { ROUTE_RPC_URL_QUERY } from './router-shared.ts'
 import { createDetachedRuntimeSignal, getRuntimeContainer } from './runtime.ts'
 import { onCleanup, onMount } from './signal.ts'
 
@@ -542,6 +543,9 @@ export const executeRealtime = async (
 const createRealtimeUrl = (id: string, input: unknown) => {
   const baseHref = typeof window !== 'undefined' ? window.location.href : 'http://localhost/'
   const url = new URL(`/__eclipsa/realtime/${encodeURIComponent(id)}`, baseHref)
+  if (typeof window !== 'undefined') {
+    url.searchParams.set(ROUTE_RPC_URL_QUERY, window.location.href)
+  }
   if (input !== undefined) {
     url.searchParams.set('input', JSON.stringify(serializePublicValue(input)))
   }

--- a/packages/eclipsa/core/router-shared.ts
+++ b/packages/eclipsa/core/router-shared.ts
@@ -6,6 +6,7 @@ export const ROUTE_PREFETCH_ATTR = 'data-e-link-prefetch'
 export const ROUTE_PREFLIGHT_ENDPOINT = '/__eclipsa/route-preflight'
 export const ROUTE_PREFLIGHT_REQUEST_HEADER = 'x-eclipsa-route-preflight'
 export const ROUTE_RPC_URL_HEADER = 'x-eclipsa-route-url'
+export const ROUTE_RPC_URL_QUERY = '__eclipsa_route_url'
 export const ROUTE_REPLACE_ATTR = 'data-e-link-replace'
 
 export interface NavigateOptions {

--- a/packages/eclipsa/vite/build/mod.test.ts
+++ b/packages/eclipsa/vite/build/mod.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { pathToFileURL } from 'node:url'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { RouteEntry } from '../utils/routing.ts'
-import { ROUTE_RPC_URL_HEADER } from '../../core/router-shared.ts'
+import { ROUTE_RPC_URL_HEADER, ROUTE_RPC_URL_QUERY } from '../../core/router-shared.ts'
 
 const mocks = vi.hoisted(() => ({
   collectAppActions: vi.fn<() => Promise<Array<{ filePath: string; id: string }>>>(),
@@ -274,7 +274,11 @@ describe('build', () => {
     expect(appSource).toContain('"/__eclipsa/realtime/:id"')
     expect(appSource).toContain('createRealtimeHonoUpgradeHandler')
     expect(appSource).toContain('const realtimeRouteMatches = new WeakMap();')
-    expect(appSource).toContain('const routeMatch = getRpcCurrentRoute(appHooks, c);')
+    expect(appSource).toContain(`c.req.query("${ROUTE_RPC_URL_QUERY}")`)
+    expect(appSource).toContain(
+      'const authorizeResponse = await resolveRequest(c, async (requestContext, appHooks) => {',
+    )
+    expect(appSource).toContain('if (!realtimeRouteMatches.has(c.req.raw)) {')
     expect(appSource).toContain('if (!routeAccess.realtimeIds.includes(id)) {')
     expect(appSource).toContain('return composeRouteMiddlewares(')
     expect(appSource).toContain('await executeRealtime(id, requestContext, socket);')

--- a/packages/eclipsa/vite/build/mod.test.ts
+++ b/packages/eclipsa/vite/build/mod.test.ts
@@ -273,6 +273,10 @@ describe('build', () => {
     expect(appSource).toContain('export const injectRealtimeWebSocket = (server) => {')
     expect(appSource).toContain('"/__eclipsa/realtime/:id"')
     expect(appSource).toContain('createRealtimeHonoUpgradeHandler')
+    expect(appSource).toContain('const realtimeRouteMatches = new WeakMap();')
+    expect(appSource).toContain('const routeMatch = getRpcCurrentRoute(appHooks, c);')
+    expect(appSource).toContain('if (!routeAccess.realtimeIds.includes(id)) {')
+    expect(appSource).toContain('return composeRouteMiddlewares(')
     expect(appSource).toContain('await executeRealtime(id, requestContext, socket);')
   })
 

--- a/packages/eclipsa/vite/build/mod.ts
+++ b/packages/eclipsa/vite/build/mod.ts
@@ -548,9 +548,11 @@ const createRouteServerAccessEntries = async (
   routes: Awaited<ReturnType<typeof createRoutes>>,
   actions: ReadonlyArray<{ filePath: string; id: string }>,
   loaders: ReadonlyArray<{ filePath: string; id: string }>,
+  realtimes: ReadonlyArray<{ filePath: string; id: string }>,
 ) => {
   const actionIdsByFilePath = toIdsByFilePath(actions)
   const loaderIdsByFilePath = toIdsByFilePath(loaders)
+  const realtimeIdsByFilePath = toIdsByFilePath(realtimes)
 
   return await Promise.all(
     routes.map(async (route) => {
@@ -560,6 +562,7 @@ const createRouteServerAccessEntries = async (
       return {
         actionIds: reachableFiles.flatMap((filePath) => actionIdsByFilePath.get(filePath) ?? []),
         loaderIds: reachableFiles.flatMap((filePath) => loaderIdsByFilePath.get(filePath) ?? []),
+        realtimeIds: reachableFiles.flatMap((filePath) => realtimeIdsByFilePath.get(filePath) ?? []),
       }
     }),
   )
@@ -606,7 +609,7 @@ const renderAppModule = (
   loaders: Array<{ filePath: string; id: string }>,
   realtimes: Array<{ filePath: string; id: string }>,
   routes: Awaited<ReturnType<typeof createRoutes>>,
-  routeServerAccessEntries: Array<{ actionIds: string[]; loaderIds: string[] }>,
+  routeServerAccessEntries: Array<{ actionIds: string[]; loaderIds: string[]; realtimeIds: string[] }>,
   routeManifest: RouteManifest,
   routeDataEndpoint: boolean,
   serverHooksUrl: string | null,
@@ -666,6 +669,7 @@ const ROUTE_PARAMS_PROP = "__eclipsa_route_params";
 const ROUTE_ERROR_PROP = "__eclipsa_route_error";
 const ROUTE_DATA_REQUEST_HEADER = ${JSON.stringify(ROUTE_DATA_REQUEST_HEADER)};
 const ROUTE_PREFLIGHT_REQUEST_HEADER = "x-eclipsa-route-preflight";
+const realtimeRouteMatches = new WeakMap();
 const CHUNK_CACHE_MESSAGE_TYPE = "eclipsa:chunk-cache-precache";
 const hooksPromise = (async () => {
   const appHooks = appHooksServerUrl ? await import(appHooksServerUrl) : {};
@@ -932,7 +936,7 @@ const reroutePathname = (hooks, request, pathname, baseUrl) =>
 const getRouteServerAccess = (route) => {
   const routeIndex = routes.indexOf(route);
   const entry = routeIndex >= 0 ? routeServerAccessEntries[routeIndex] : null;
-  return entry ?? { actionIds: [], loaderIds: [] };
+  return entry ?? { actionIds: [], loaderIds: [], realtimeIds: [] };
 };
 
 const resolveRouteForCurrentUrl = (hooks, request, currentUrl) => {
@@ -1577,6 +1581,15 @@ if (realtimeWebSocket?.upgradeWebSocket) {
       if (!id) {
         return c.text("Not Found", 404);
       }
+      const { appHooks } = await hooksPromise;
+      const routeMatch = getRpcCurrentRoute(appHooks, c);
+      if (!routeMatch) {
+        return c.text("Bad Request", 400);
+      }
+      const routeAccess = getRouteServerAccess(routeMatch.route);
+      if (!routeAccess.realtimeIds.includes(id)) {
+        return c.text("Not Found", 404);
+      }
       const moduleUrl = realtimes[id];
       if (!moduleUrl) {
         return c.text("Not Found", 404);
@@ -1584,13 +1597,25 @@ if (realtimeWebSocket?.upgradeWebSocket) {
       if (!hasRealtime(id)) {
         await import(moduleUrl);
       }
+      realtimeRouteMatches.set(c.req.raw, routeMatch);
       await next();
     },
     createRealtimeHonoUpgradeHandler(realtimeWebSocket.upgradeWebSocket, async (c, socket) => {
-      await resolveRequest(c, async (requestContext) => {
+      await resolveRequest(c, async (requestContext, appHooks) => {
         const id = requestContext.req.param("id");
-        await executeRealtime(id, requestContext, socket);
-        return requestContext.body(null, 204);
+        const routeMatch = realtimeRouteMatches.get(requestContext.req.raw) ?? getRpcCurrentRoute(appHooks, requestContext);
+        if (!routeMatch) {
+          return requestContext.text("Bad Request", 400);
+        }
+        return composeRouteMiddlewares(
+          routeMatch.route,
+          requestContext,
+          routeMatch.params,
+          async () => {
+            await executeRealtime(id, requestContext, socket);
+            return requestContext.body(null, 204);
+          },
+        );
       });
     }),
   );
@@ -1858,7 +1883,7 @@ export const build = async (
   const loaders = await collectAppLoaders(root)
   const realtimes = await collectAppRealtimes(root)
   const routes = await createRoutes(root)
-  const routeServerAccessEntries = await createRouteServerAccessEntries(routes, actions, loaders)
+  const routeServerAccessEntries = await createRouteServerAccessEntries(routes, actions, loaders, realtimes)
   const staticPageRoutes = routes.filter(
     (route) => route.page && resolveRouteRenderMode(route, options.output) === 'static',
   )

--- a/packages/eclipsa/vite/build/mod.ts
+++ b/packages/eclipsa/vite/build/mod.ts
@@ -17,6 +17,7 @@ import {
   ROUTE_MANIFEST_ELEMENT_ID,
   ROUTE_PREFLIGHT_ENDPOINT,
   ROUTE_RPC_URL_HEADER,
+  ROUTE_RPC_URL_QUERY,
 } from '../../core/router-shared.ts'
 import {
   createBuildModuleUrl,
@@ -562,7 +563,9 @@ const createRouteServerAccessEntries = async (
       return {
         actionIds: reachableFiles.flatMap((filePath) => actionIdsByFilePath.get(filePath) ?? []),
         loaderIds: reachableFiles.flatMap((filePath) => loaderIdsByFilePath.get(filePath) ?? []),
-        realtimeIds: reachableFiles.flatMap((filePath) => realtimeIdsByFilePath.get(filePath) ?? []),
+        realtimeIds: reachableFiles.flatMap(
+          (filePath) => realtimeIdsByFilePath.get(filePath) ?? [],
+        ),
       }
     }),
   )
@@ -609,7 +612,11 @@ const renderAppModule = (
   loaders: Array<{ filePath: string; id: string }>,
   realtimes: Array<{ filePath: string; id: string }>,
   routes: Awaited<ReturnType<typeof createRoutes>>,
-  routeServerAccessEntries: Array<{ actionIds: string[]; loaderIds: string[]; realtimeIds: string[] }>,
+  routeServerAccessEntries: Array<{
+    actionIds: string[]
+    loaderIds: string[]
+    realtimeIds: string[]
+  }>,
   routeManifest: RouteManifest,
   routeDataEndpoint: boolean,
   serverHooksUrl: string | null,
@@ -951,13 +958,13 @@ const resolveRouteForCurrentUrl = (hooks, request, currentUrl) => {
 
 const getRpcCurrentRoute = (hooks, c) => {
   const requestUrl = getRequestUrl(c.req.raw);
-  const routeUrlHeader = c.req.header(${JSON.stringify(ROUTE_RPC_URL_HEADER)});
-  if (!routeUrlHeader) {
+  const routeUrl = c.req.header(${JSON.stringify(ROUTE_RPC_URL_HEADER)}) ?? c.req.query(${JSON.stringify(ROUTE_RPC_URL_QUERY)});
+  if (!routeUrl) {
     return null;
   }
   let currentUrl;
   try {
-    currentUrl = new URL(routeUrlHeader, requestUrl);
+    currentUrl = new URL(routeUrl, requestUrl);
   } catch {
     return null;
   }
@@ -1577,46 +1584,65 @@ if (realtimeWebSocket?.upgradeWebSocket) {
   app.get(
     "/__eclipsa/realtime/:id",
     async (c, next) => {
-      const id = c.req.param("id");
-      if (!id) {
-        return c.text("Not Found", 404);
-      }
-      const { appHooks } = await hooksPromise;
-      const routeMatch = getRpcCurrentRoute(appHooks, c);
-      if (!routeMatch) {
-        return c.text("Bad Request", 400);
-      }
-      const routeAccess = getRouteServerAccess(routeMatch.route);
-      if (!routeAccess.realtimeIds.includes(id)) {
-        return c.text("Not Found", 404);
-      }
-      const moduleUrl = realtimes[id];
-      if (!moduleUrl) {
-        return c.text("Not Found", 404);
-      }
-      if (!hasRealtime(id)) {
-        await import(moduleUrl);
-      }
-      realtimeRouteMatches.set(c.req.raw, routeMatch);
-      await next();
-    },
-    createRealtimeHonoUpgradeHandler(realtimeWebSocket.upgradeWebSocket, async (c, socket) => {
-      await resolveRequest(c, async (requestContext, appHooks) => {
+      const authorizeResponse = await resolveRequest(c, async (requestContext, appHooks) => {
         const id = requestContext.req.param("id");
-        const routeMatch = realtimeRouteMatches.get(requestContext.req.raw) ?? getRpcCurrentRoute(appHooks, requestContext);
+        if (!id) {
+          return requestContext.text("Not Found", 404);
+        }
+        const routeMatch = getRpcCurrentRoute(appHooks, requestContext);
         if (!routeMatch) {
           return requestContext.text("Bad Request", 400);
         }
-        return composeRouteMiddlewares(
+        const routeAccess = getRouteServerAccess(routeMatch.route);
+        if (!routeAccess.realtimeIds.includes(id)) {
+          return requestContext.text("Not Found", 404);
+        }
+        const moduleUrl = realtimes[id];
+        if (!moduleUrl) {
+          return requestContext.text("Not Found", 404);
+        }
+        if (!hasRealtime(id)) {
+          await import(moduleUrl);
+        }
+        let allowedResponse = null;
+        const routeMiddlewareResponse = await composeRouteMiddlewares(
           routeMatch.route,
           requestContext,
           routeMatch.params,
           async () => {
-            await executeRealtime(id, requestContext, socket);
-            return requestContext.body(null, 204);
+            allowedResponse = requestContext.body(null, 204);
+            return allowedResponse;
           },
         );
+        if (routeMiddlewareResponse !== allowedResponse) {
+          return routeMiddlewareResponse;
+        }
+        realtimeRouteMatches.set(requestContext.req.raw, id);
+        return allowedResponse;
       });
+      if (!realtimeRouteMatches.has(c.req.raw)) {
+        return authorizeResponse;
+      }
+      await next();
+    },
+    createRealtimeHonoUpgradeHandler(realtimeWebSocket.upgradeWebSocket, async (c, socket) => {
+      const { appHooks, serverHooks } = await hooksPromise;
+      const requestContext = prepareRequestContext(c, serverHooks);
+      await withServerRequestContext(
+        requestContext,
+        {
+          handleError: serverHooks.handleError,
+          transport: appHooks.transport,
+        },
+        async () => {
+          const id = realtimeRouteMatches.get(requestContext.req.raw);
+          if (!id) {
+            return requestContext.text("Bad Request", 400);
+          }
+          await executeRealtime(id, requestContext, socket);
+          return requestContext.body(null, 204);
+        },
+      );
     }),
   );
 }
@@ -1883,7 +1909,12 @@ export const build = async (
   const loaders = await collectAppLoaders(root)
   const realtimes = await collectAppRealtimes(root)
   const routes = await createRoutes(root)
-  const routeServerAccessEntries = await createRouteServerAccessEntries(routes, actions, loaders, realtimes)
+  const routeServerAccessEntries = await createRouteServerAccessEntries(
+    routes,
+    actions,
+    loaders,
+    realtimes,
+  )
   const staticPageRoutes = routes.filter(
     (route) => route.page && resolveRouteRenderMode(route, options.output) === 'static',
   )

--- a/packages/eclipsa/vite/dev-app/mod.test.ts
+++ b/packages/eclipsa/vite/dev-app/mod.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import * as path from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { RouteEntry } from '../utils/routing.ts'
-import { ROUTE_RPC_URL_HEADER } from '../../core/router-shared.ts'
+import { ROUTE_RPC_URL_HEADER, ROUTE_RPC_URL_QUERY } from '../../core/router-shared.ts'
 
 var createRoutes = vi.fn<() => Promise<RouteEntry[]>>()
 var collectAppActions = vi.fn<() => Promise<{ id: string; filePath: string }[]>>()
@@ -234,11 +234,9 @@ describe('createDevFetch', () => {
 
     await devFetch.installWebSocket()
     const response = await devFetch.fetch(
-      new Request('http://localhost/__eclipsa/realtime/room', {
-        headers: {
-          [ROUTE_RPC_URL_HEADER]: 'http://localhost/',
-        },
-      }),
+      new Request(
+        `http://localhost/__eclipsa/realtime/room?${ROUTE_RPC_URL_QUERY}=${encodeURIComponent('http://localhost/')}`,
+      ),
     )
 
     expect(response?.status).toBe(200)
@@ -304,9 +302,7 @@ describe('createDevFetch', () => {
         server: null,
       },
     ]
-    collectAppRealtimes.mockResolvedValue([
-      { filePath: securePagePath, id: 'secure-room' },
-    ])
+    collectAppRealtimes.mockResolvedValue([{ filePath: securePagePath, id: 'secure-room' }])
 
     const devFetch = createDevFetch({
       resolvedConfig: {
@@ -360,6 +356,90 @@ describe('createDevFetch', () => {
     )
     expect(blocked).toBeUndefined()
     expect(executeRealtime).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects realtime upgrades when route middleware short-circuits', async () => {
+    const root = await fs.mkdtemp(path.join(tmpdir(), 'eclipsa-dev-realtime-auth-'))
+    const securePagePath = await writeRouteModule(root, 'secure/+page.tsx')
+    const secureMiddlewarePath = await writeRouteModule(
+      root,
+      'secure/+middleware.ts',
+      'export default (c) => c.text("Forbidden", 403);\n',
+    )
+    const executeRealtime = vi.fn()
+    const upgradeHandler = vi.fn((c: any) => c.text('upgraded'))
+    const upgradeWebSocket = vi.fn(() => upgradeHandler)
+    routes = [
+      {
+        error: null,
+        layouts: [],
+        loading: null,
+        middlewares: [
+          {
+            entryName: 'special__secure__middleware',
+            filePath: secureMiddlewarePath,
+          },
+        ],
+        notFound: null,
+        page: {
+          entryName: 'route__secure__page',
+          filePath: securePagePath,
+        },
+        routePath: '/secure',
+        segments: [{ kind: 'static', value: 'secure' }],
+        server: null,
+      },
+    ]
+    collectAppRealtimes.mockResolvedValue([{ filePath: securePagePath, id: 'secure-room' }])
+
+    const devFetch = createDevFetch({
+      resolvedConfig: {
+        root,
+      } as any,
+      devServer: {} as any,
+      deps: {
+        collectAppActions,
+        collectAppLoaders,
+        collectAppRealtimes,
+        collectAppSymbols,
+        createDevModuleUrl,
+        createDevSymbolUrl,
+        createRoutes,
+      },
+      runner: {
+        async import(id: string) {
+          if (id === '/app/+server-entry.ts') {
+            return {
+              default: userApp,
+              realtimeWebSocket: () => ({ upgradeWebSocket }),
+            }
+          }
+          if (id === secureMiddlewarePath) {
+            return {
+              default: (c: any) => c.text('Forbidden', 403),
+            }
+          }
+          if (id === 'eclipsa') {
+            return {
+              executeRealtime,
+              hasRealtime: () => true,
+            }
+          }
+          return {}
+        },
+      } as any,
+      ssrEnv: {} as any,
+    })
+
+    const response = await devFetch.fetch(
+      new Request(
+        `http://localhost/__eclipsa/realtime/secure-room?${ROUTE_RPC_URL_QUERY}=${encodeURIComponent('http://localhost/secure')}`,
+      ),
+    )
+
+    expect(response?.status).toBe(403)
+    expect(upgradeHandler).not.toHaveBeenCalled()
+    expect(executeRealtime).not.toHaveBeenCalled()
   })
 
   it('renders ancestor layouts around the page component', async () => {

--- a/packages/eclipsa/vite/dev-app/mod.test.ts
+++ b/packages/eclipsa/vite/dev-app/mod.test.ts
@@ -155,6 +155,24 @@ describe('createDevFetch', () => {
   })
 
   it('mounts configured Hono-compatible realtime websocket adapters', async () => {
+    const root = await fs.mkdtemp(path.join(tmpdir(), 'eclipsa-dev-realtime-'))
+    const pagePath = await writeRouteModule(root, '+page.tsx')
+    routes = [
+      {
+        error: null,
+        layouts: [],
+        loading: null,
+        middlewares: [],
+        notFound: null,
+        page: {
+          entryName: 'route__page',
+          filePath: pagePath,
+        },
+        routePath: '/',
+        segments: [],
+        server: null,
+      },
+    ]
     let events: {
       onMessage?: (
         event: { data: unknown },
@@ -177,11 +195,11 @@ describe('createDevFetch', () => {
       injectWebSocket,
       upgradeWebSocket,
     }))
-    collectAppRealtimes.mockResolvedValue([{ filePath: '/tmp/app/room.ts', id: 'room' }])
+    collectAppRealtimes.mockResolvedValue([{ filePath: pagePath, id: 'room' }])
 
     const devFetch = createDevFetch({
       resolvedConfig: {
-        root: '/tmp',
+        root,
       } as any,
       devServer: { httpServer } as any,
       deps: {
@@ -215,7 +233,13 @@ describe('createDevFetch', () => {
     })
 
     await devFetch.installWebSocket()
-    const response = await devFetch.fetch(new Request('http://localhost/__eclipsa/realtime/room'))
+    const response = await devFetch.fetch(
+      new Request('http://localhost/__eclipsa/realtime/room', {
+        headers: {
+          [ROUTE_RPC_URL_HEADER]: 'http://localhost/',
+        },
+      }),
+    )
 
     expect(response?.status).toBe(200)
     expect(realtimeWebSocket).toHaveBeenCalledWith(
@@ -223,7 +247,7 @@ describe('createDevFetch', () => {
     )
     expect(injectWebSocket).toHaveBeenCalledWith(httpServer)
     expect(upgradeWebSocket).toHaveBeenCalledTimes(1)
-    expect(moduleImports).toContain('/tmp/app/room.ts')
+    expect(moduleImports).toContain(pagePath)
     await Promise.resolve()
     expect(executeRealtime).toHaveBeenCalledWith(
       'room',
@@ -234,6 +258,108 @@ describe('createDevFetch', () => {
       }),
     )
     expect(events?.onOpen).toEqual(expect.any(Function))
+  })
+
+  it('rejects realtime requests outside the current route graph', async () => {
+    const root = await fs.mkdtemp(path.join(tmpdir(), 'eclipsa-dev-realtime-graph-'))
+    const securePagePath = await writeRouteModule(root, 'secure/[id]/+page.tsx')
+    const publicPagePath = await writeRouteModule(root, 'public/+page.tsx')
+    const hasRealtime = vi.fn(() => true)
+    const executeRealtime = vi.fn()
+    const upgradeWebSocket = vi.fn((createEvents: (c: any) => any) => (c: any) => {
+      const events = createEvents(c)
+      void events.onOpen?.({}, { close() {}, send() {} })
+      return c.text('upgraded')
+    })
+    routes = [
+      {
+        error: null,
+        layouts: [],
+        loading: null,
+        middlewares: [],
+        notFound: null,
+        page: {
+          entryName: 'route__secure___id___page',
+          filePath: securePagePath,
+        },
+        routePath: '/secure/[id]',
+        segments: [
+          { kind: 'static', value: 'secure' },
+          { kind: 'required', value: 'id' },
+        ],
+        server: null,
+      },
+      {
+        error: null,
+        layouts: [],
+        loading: null,
+        middlewares: [],
+        notFound: null,
+        page: {
+          entryName: 'route__public__page',
+          filePath: publicPagePath,
+        },
+        routePath: '/public',
+        segments: [{ kind: 'static', value: 'public' }],
+        server: null,
+      },
+    ]
+    collectAppRealtimes.mockResolvedValue([
+      { filePath: securePagePath, id: 'secure-room' },
+    ])
+
+    const devFetch = createDevFetch({
+      resolvedConfig: {
+        root,
+      } as any,
+      devServer: {} as any,
+      deps: {
+        collectAppActions,
+        collectAppLoaders,
+        collectAppRealtimes,
+        collectAppSymbols,
+        createDevModuleUrl,
+        createDevSymbolUrl,
+        createRoutes,
+      },
+      runner: {
+        async import(id: string) {
+          if (id === '/app/+server-entry.ts') {
+            return {
+              default: userApp,
+              realtimeWebSocket: () => ({ upgradeWebSocket }),
+            }
+          }
+          if (id === 'eclipsa') {
+            return {
+              executeRealtime,
+              hasRealtime,
+            }
+          }
+          return {}
+        },
+      } as any,
+      ssrEnv: {} as any,
+    })
+
+    const allowed = await devFetch.fetch(
+      new Request('http://localhost/__eclipsa/realtime/secure-room', {
+        headers: {
+          [ROUTE_RPC_URL_HEADER]: 'http://localhost/secure/123',
+        },
+      }),
+    )
+    expect(allowed?.status).toBe(200)
+
+    const blocked = await devFetch.fetch(
+      new Request('http://localhost/__eclipsa/realtime/secure-room', {
+        headers: {
+          [ROUTE_RPC_URL_HEADER]: 'http://localhost/public',
+        },
+      }),
+    )
+    expect(blocked).toBeUndefined()
+    expect(executeRealtime).toHaveBeenCalledTimes(1)
   })
 
   it('renders ancestor layouts around the page component', async () => {

--- a/packages/eclipsa/vite/dev-app/mod.ts
+++ b/packages/eclipsa/vite/dev-app/mod.ts
@@ -10,6 +10,7 @@ import {
   ROUTE_PREFLIGHT_ENDPOINT,
   ROUTE_PREFLIGHT_REQUEST_HEADER,
   ROUTE_RPC_URL_HEADER,
+  ROUTE_RPC_URL_QUERY,
   type RouteParams,
 } from '../../core/router-shared.ts'
 import {
@@ -603,13 +604,15 @@ const createDevApp = async (init: DevAppInit) => {
 
   const getRpcCurrentRoute = (requestContext: AppContext) => {
     const requestUrl = getRequestUrl(requestContext.req.raw)
-    const routeUrlHeader = requestContext.req.header(ROUTE_RPC_URL_HEADER)
-    if (!routeUrlHeader) {
+    const routeUrl =
+      requestContext.req.header(ROUTE_RPC_URL_HEADER) ??
+      requestContext.req.query(ROUTE_RPC_URL_QUERY)
+    if (!routeUrl) {
       return null
     }
     let currentUrl: URL
     try {
-      currentUrl = new URL(routeUrlHeader, requestUrl)
+      currentUrl = new URL(routeUrl, requestUrl)
     } catch {
       return null
     }
@@ -618,10 +621,7 @@ const createDevApp = async (init: DevAppInit) => {
     }
     return resolveRouteForCurrentUrl(requestContext.req.raw, currentUrl)
   }
-  const realtimeRouteMatches = new WeakMap<
-    Request,
-    ReturnType<typeof resolveRouteForCurrentUrl>
-  >()
+  const realtimeRouteMatches = new WeakMap<Request, string>()
 
   const resolveRequest = async <E extends Context>(
     c: E,
@@ -1215,48 +1215,66 @@ const createDevApp = async (init: DevAppInit) => {
     app.get(
       '/__eclipsa/realtime/:id',
       async (c, next) => {
-        const id = c.req.param('id')
-        if (!id) {
-          return c.text('Not Found', 404)
-        }
-        const routeMatch = getRpcCurrentRoute(c as unknown as AppContext)
-        if (!routeMatch) {
-          return c.text('Bad Request', 400)
-        }
-        const routeAccess = getRouteServerAccess(routeMatch.route)
-        if (!routeAccess.realtimeIds.has(id)) {
-          return c.text('Not Found', 404)
-        }
-        const modulePath = realtimeModules.get(id)
-        if (!modulePath) {
-          return c.text('Not Found', 404)
-        }
-        const { hasRealtime } = await init.runner.import('eclipsa')
-        if (!hasRealtime(id)) {
-          await init.runner.import(modulePath)
-        }
-        realtimeRouteMatches.set(c.req.raw, routeMatch)
-        await next()
-      },
-      createRealtimeHonoUpgradeHandler(realtimeWebSocket.upgradeWebSocket, async (c, socket) => {
-        await resolveRequest(c, async (requestContext) => {
-          const { executeRealtime } = await init.runner.import('eclipsa')
+        const authorizeResponse = await resolveRequest(c, async (requestContext) => {
           const id = requestContext.req.param('id')
-          const routeMatch =
-            realtimeRouteMatches.get(requestContext.req.raw) ?? getRpcCurrentRoute(requestContext)
+          if (!id) {
+            return requestContext.text('Not Found', 404)
+          }
+          const routeMatch = getRpcCurrentRoute(requestContext)
           if (!routeMatch) {
             return requestContext.text('Bad Request', 400)
           }
-          return composeRouteMiddlewares(
+          const routeAccess = getRouteServerAccess(routeMatch.route)
+          if (!routeAccess.realtimeIds.has(id)) {
+            return requestContext.text('Not Found', 404)
+          }
+          const modulePath = realtimeModules.get(id)
+          if (!modulePath) {
+            return requestContext.text('Not Found', 404)
+          }
+          const { hasRealtime } = await init.runner.import('eclipsa')
+          if (!hasRealtime(id)) {
+            await init.runner.import(modulePath)
+          }
+          let allowedResponse: Response | null = null
+          const routeMiddlewareResponse = await composeRouteMiddlewares(
             routeMatch.route,
             requestContext,
             routeMatch.params,
             async () => {
-              await executeRealtime(id, requestContext, socket)
-              return requestContext.body(null, 204)
+              allowedResponse = requestContext.body(null, 204)
+              return allowedResponse
             },
-          ) as Promise<Response>
+          )
+          if (routeMiddlewareResponse !== allowedResponse) {
+            return routeMiddlewareResponse as Response
+          }
+          realtimeRouteMatches.set(requestContext.req.raw, id)
+          return allowedResponse
         })
+        if (!realtimeRouteMatches.has(c.req.raw)) {
+          return authorizeResponse
+        }
+        await next()
+      },
+      createRealtimeHonoUpgradeHandler(realtimeWebSocket.upgradeWebSocket, async (c, socket) => {
+        const requestContext = prepareRequestContext(c)
+        await withServerRequestContext(
+          requestContext,
+          {
+            handleError: serverHooks.handleError,
+            transport: appHooks.transport,
+          },
+          async () => {
+            const { executeRealtime } = await init.runner.import('eclipsa')
+            const id = realtimeRouteMatches.get(requestContext.req.raw)
+            if (!id) {
+              return requestContext.text('Bad Request', 400)
+            }
+            await executeRealtime(id, requestContext, socket)
+            return requestContext.body(null, 204)
+          },
+        )
       }),
     )
   }

--- a/packages/eclipsa/vite/dev-app/mod.ts
+++ b/packages/eclipsa/vite/dev-app/mod.ts
@@ -160,6 +160,7 @@ interface RouteDataResponse {
 interface RouteServerAccessEntry {
   actionIds: Set<string>
   loaderIds: Set<string>
+  realtimeIds: Set<string>
   route: RouteEntry
 }
 
@@ -246,9 +247,11 @@ const createRouteServerAccessEntries = async (
   routes: readonly RouteEntry[],
   actions: ReadonlyArray<{ filePath: string; id: string }>,
   loaders: ReadonlyArray<{ filePath: string; id: string }>,
+  realtimes: ReadonlyArray<{ filePath: string; id: string }>,
 ) => {
   const actionIdsByFilePath = toIdsByFilePath(actions)
   const loaderIdsByFilePath = toIdsByFilePath(loaders)
+  const realtimeIdsByFilePath = toIdsByFilePath(realtimes)
 
   return await Promise.all(
     routes.map(async (route) => {
@@ -261,6 +264,9 @@ const createRouteServerAccessEntries = async (
         ),
         loaderIds: new Set(
           reachableFiles.flatMap((filePath) => loaderIdsByFilePath.get(filePath) ?? []),
+        ),
+        realtimeIds: new Set(
+          reachableFiles.flatMap((filePath) => realtimeIdsByFilePath.get(filePath) ?? []),
         ),
         route,
       } satisfies RouteServerAccessEntry
@@ -524,7 +530,12 @@ const createDevApp = async (init: DevAppInit) => {
   const actionModules = new Map(actions.map((action) => [action.id, action.filePath]))
   const loaderModules = new Map(loaders.map((loader) => [loader.id, loader.filePath]))
   const realtimeModules = new Map(realtimes.map((realtime) => [realtime.id, realtime.filePath]))
-  const routeServerAccessEntries = await createRouteServerAccessEntries(routes, actions, loaders)
+  const routeServerAccessEntries = await createRouteServerAccessEntries(
+    routes,
+    actions,
+    loaders,
+    realtimes,
+  )
   const routeServerAccessByRoute = new Map(
     routeServerAccessEntries.map((entry) => [entry.route, entry] as const),
   )
@@ -569,6 +580,7 @@ const createDevApp = async (init: DevAppInit) => {
     routeServerAccessByRoute.get(route) ?? {
       actionIds: new Set<string>(),
       loaderIds: new Set<string>(),
+      realtimeIds: new Set<string>(),
       route,
     }
 
@@ -606,6 +618,10 @@ const createDevApp = async (init: DevAppInit) => {
     }
     return resolveRouteForCurrentUrl(requestContext.req.raw, currentUrl)
   }
+  const realtimeRouteMatches = new WeakMap<
+    Request,
+    ReturnType<typeof resolveRouteForCurrentUrl>
+  >()
 
   const resolveRequest = async <E extends Context>(
     c: E,
@@ -1203,6 +1219,14 @@ const createDevApp = async (init: DevAppInit) => {
         if (!id) {
           return c.text('Not Found', 404)
         }
+        const routeMatch = getRpcCurrentRoute(c as unknown as AppContext)
+        if (!routeMatch) {
+          return c.text('Bad Request', 400)
+        }
+        const routeAccess = getRouteServerAccess(routeMatch.route)
+        if (!routeAccess.realtimeIds.has(id)) {
+          return c.text('Not Found', 404)
+        }
         const modulePath = realtimeModules.get(id)
         if (!modulePath) {
           return c.text('Not Found', 404)
@@ -1211,14 +1235,27 @@ const createDevApp = async (init: DevAppInit) => {
         if (!hasRealtime(id)) {
           await init.runner.import(modulePath)
         }
+        realtimeRouteMatches.set(c.req.raw, routeMatch)
         await next()
       },
       createRealtimeHonoUpgradeHandler(realtimeWebSocket.upgradeWebSocket, async (c, socket) => {
         await resolveRequest(c, async (requestContext) => {
           const { executeRealtime } = await init.runner.import('eclipsa')
           const id = requestContext.req.param('id')
-          await executeRealtime(id, requestContext, socket)
-          return requestContext.body(null, 204)
+          const routeMatch =
+            realtimeRouteMatches.get(requestContext.req.raw) ?? getRpcCurrentRoute(requestContext)
+          if (!routeMatch) {
+            return requestContext.text('Bad Request', 400)
+          }
+          return composeRouteMiddlewares(
+            routeMatch.route,
+            requestContext,
+            routeMatch.params,
+            async () => {
+              await executeRealtime(id, requestContext, socket)
+              return requestContext.body(null, 204)
+            },
+          ) as Promise<Response>
         })
       }),
     )


### PR DESCRIPTION
### Motivation
- Realtime WebSocket endpoints were callable by ID alone and bypassed the route-bound authorization, route middleware, and same-origin RPC checks that protect actions/loaders. 
- Because realtime handlers are collected globally, any client that knows an ID could invoke privileged server logic for routes that expect middleware-based protections.

### Description
- Add `realtimeIds` to the route server access metadata and include realtimes when building `routeServerAccessEntries` so realtime handlers are scoped to reachable route files. 
- Enforce RPC route resolution with `getRpcCurrentRoute(...)` and check membership of the requested realtime `id` against `routeAccess.realtimeIds` in both the build-time app (`packages/eclipsa/vite/build/mod.ts`) and dev app (`packages/eclipsa/vite/dev-app/mod.ts`). 
- Execute realtime handlers through `composeRouteMiddlewares(...)` so route middlewares and server hooks run before `executeRealtime(...)`. 
- Cache the pre-upgrade route match for the websocket upgrade using a per-request `WeakMap` and reuse it during the websocket handler execution to keep checks consistent across the upgrade boundary. 
- Update and add tests to assert emitted build source includes realtime auth checks and to verify dev realtime requests are permitted only when the RPC route context authorizes the realtime ID. 

### Testing
- Ran `bunx tsc -p tsconfig.json --noEmit` and it completed successfully. 
- Ran `bun run test vite/build/mod.test.ts vite/dev-app/mod.test.ts` (from `packages/eclipsa`) and the updated test suite passed (`48` tests passed across both files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f027638a588332952c9175b15f1b89)